### PR TITLE
docs: include sys import in installer pseudocode

### DIFF
--- a/docs/Smart-Installer.md
+++ b/docs/Smart-Installer.md
@@ -40,6 +40,7 @@ This document sketches a design for an automated installer that sets up an AI ec
 # detect system info
 import wmi
 import subprocess
+import sys
 
 def detect_specs():
     c = wmi.WMI()


### PR DESCRIPTION
## Summary
- add missing `sys` import to Smart Installer pseudocode so example commands have all required modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c318362a8832695c442dd305c59d0