### PR TITLE
feat: manage stored API keys

### DIFF
--- a/installer/cli.py
+++ b/installer/cli.py
@@ -18,6 +18,16 @@ def main() -> None:
         action="store_true",
         help="print the directory where API keys are stored",
     )
+    parser.add_argument(
+        "--list-keys",
+        action="store_true",
+        help="list stored API keys",
+    )
+    parser.add_argument(
+        "--delete-key",
+        metavar="SERVICE",
+        help="delete the stored API key for SERVICE",
+    )
     args = parser.parse_args()
 
     info = system_info.detect_system()
@@ -31,10 +41,29 @@ def main() -> None:
     if args.show_config_dir:
         print(f"Config directory: {api_keys.CONFIG_DIR}")
 
-    if input("Would you like to add an API key? (y/N) ").strip().lower() == "y":
-        api_keys.prompt_and_save()
-    else:
-        print("No API key stored.")
+    performed_action = False
+    if args.list_keys:
+        keys = api_keys.list_keys()
+        if keys:
+            print("Stored API keys:")
+            for service in keys:
+                print(f"- {service}")
+        else:
+            print("No API keys stored.")
+        performed_action = True
+
+    if args.delete_key:
+        if api_keys.delete_key(args.delete_key):
+            print(f"Deleted key for {args.delete_key}")
+        else:
+            print(f"No key stored for {args.delete_key}")
+        performed_action = True
+
+    if not performed_action:
+        if input("Would you like to add an API key? (y/N) ").strip().lower() == "y":
+            api_keys.prompt_and_save()
+        else:
+            print("No API key stored.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow listing or deleting stored API keys from the installer CLI
- add helper functions for listing and deleting keys in keyring
- only prompt to add a key when no key-management flags are used

## Testing
- `python -m py_compile installer/cli.py installer/api_keys.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cc58f00d0832688590fe82f274a16