### PR TITLE
Add installer plugin registry and documentation

### DIFF
--- a/docs/Installer-Plugins.md
+++ b/docs/Installer-Plugins.md
@@ -1,0 +1,50 @@
+# Installer Plugin System
+
+The installer can be extended through a lightweight plugin mechanism. Plugins
+can request additional dependencies or register UI components that will be
+exposed by the installer.
+
+## Discovery
+
+Plugins are discovered in two ways:
+
+1. **Entry points** – any installed package that defines an
+   `installer_plugins` entry point will be loaded.
+2. **Directory scanning** – pass a directory to
+   `discover_plugins()` and each `.py` file in that directory will be imported.
+   Files beginning with `_` are ignored.
+
+## Writing a Plugin
+
+A plugin is simply a callable that accepts a `PluginRegistry` instance. Most
+modules expose a `register(registry)` function:
+
+```python
+# my_plugin.py
+
+def register(registry):
+    registry.add_dependency("requests>=2.0")
+    registry.register_ui_component("hello", lambda: print("Hello!"))
+```
+
+To distribute the plugin as a package, declare an entry point in `pyproject.toml`:
+
+```toml
+[project.entry-points."installer_plugins"]
+"my-plugin" = "my_plugin:register"
+```
+
+## Loading Plugins
+
+Use :func:`discover_plugins` to load all available plugins:
+
+```python
+from installer.plugins import discover_plugins
+
+registry = discover_plugins("./local_plugins")
+print(registry.dependencies)
+print(registry.ui_components)
+```
+
+The returned registry lists all requested dependencies and registered UI
+components so the installer can act on them.

--- a/installer/plugins.py
+++ b/installer/plugins.py
@@ -1,0 +1,85 @@
+"""Plugin registry and discovery for the installer."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+@dataclass
+class PluginRegistry:
+    """Collects contributions from installer plugins.
+
+    Plugins can request extra dependencies or register UI components.  The
+    registry simply stores these requests so the installer can act on them
+    later.
+    """
+
+    dependencies: set[str] = field(default_factory=set)
+    ui_components: dict[str, Any] = field(default_factory=dict)
+
+    def add_dependency(self, requirement: str) -> None:
+        """Request installation of an additional package."""
+
+        self.dependencies.add(requirement)
+
+    def register_ui_component(self, name: str, component: Any) -> None:
+        """Register a UI component provided by a plugin."""
+
+        self.ui_components[name] = component
+
+
+def _apply_plugin(plugin: Any, registry: PluginRegistry) -> None:
+    """Invoke a plugin object, module, or factory with the registry."""
+
+    if hasattr(plugin, "register") and callable(plugin.register):
+        plugin.register(registry)
+    elif callable(plugin):
+        plugin(registry)
+    else:
+        raise TypeError("Plugin must be callable or expose a register() function")
+
+
+def _load_module(path: Path) -> ModuleType:
+    spec = spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load plugin module from {path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def discover_plugins(search_path: str | Path | None = None) -> PluginRegistry:
+    """Discover plugins via entry points and an optional directory.
+
+    Parameters
+    ----------
+    search_path:
+        Directory containing plugin modules.  Each ``.py`` file will be imported
+        and expected to expose a ``register(registry)`` function.  Files starting
+        with ``_`` are ignored.
+    """
+
+    registry = PluginRegistry()
+
+    # Entry points
+    for ep in entry_points().select(group="installer_plugins"):
+        plugin = ep.load()
+        _apply_plugin(plugin, registry)
+
+    # Search directory
+    if search_path is not None:
+        path = Path(search_path)
+        for file in path.glob("*.py"):
+            if file.name.startswith("_"):
+                continue
+            module = _load_module(file)
+            _apply_plugin(module, registry)
+
+    return registry
+
+
+__all__ = ["PluginRegistry", "discover_plugins"]


### PR DESCRIPTION
## Summary
- add a plugin registry that discovers plugins from an entry point group or directory
- provide hooks for plugins to request dependencies and register UI components
- document how to write and load installer plugins

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688cce19e6048326b01610e9fa374c6a