### PR TITLE
feat: manage plugin virtual environments

### DIFF
--- a/docs/Smart-Installer.md
+++ b/docs/Smart-Installer.md
@@ -35,6 +35,30 @@ This document sketches a design for an automated installer that sets up an AI ec
 6. **Updates and Plugins**
    - Check periodically for new plugins or tools. Allow users to review and install updates within the GUI.
 
+## Plugin Environments
+
+Plugins and toolsets are installed into isolated Python environments managed by
+``installer.env``. Each plugin can request dependencies and the installer will
+create a dedicated ``venv`` under ``~/.windows_ai/venvs/<name>`` to avoid
+package conflicts.
+
+```python
+from installer import env
+
+# ensure a virtual environment for "example-plugin"
+env_path = env.create_env("example-plugin")
+env.install_packages(env_path, ["requests"])
+```
+
+Run the CLI with ``--install-all`` to discover plugins and install their
+dependencies in the ``plugins`` environment:
+
+```
+python -m installer.cli --install-all
+```
+
+The GUI's **Install All** button performs the same operation.
+
 ## Example Pseudocode
 ```python
 # detect system info

--- a/installer/cli.py
+++ b/installer/cli.py
@@ -8,7 +8,20 @@ from __future__ import annotations
 import argparse
 import json
 
-from . import system_info, api_keys
+from . import system_info, api_keys, plugins, env
+
+
+def install_all() -> None:
+    """Discover plugins and install their requested dependencies."""
+
+    registry = plugins.discover_plugins()
+    deps = sorted(registry.dependencies)
+    if not deps:
+        print("No plugin dependencies to install.")
+        return
+    env_path = env.create_env("plugins")
+    env.install_packages(env_path, deps)
+    print(f"Installed {len(deps)} packages into {env_path}")
 
 
 def main() -> None:
@@ -27,6 +40,11 @@ def main() -> None:
         "--delete-key",
         metavar="SERVICE",
         help="delete the stored API key for SERVICE",
+    )
+    parser.add_argument(
+        "--install-all",
+        action="store_true",
+        help="install plugin dependencies in their own environment",
     )
     args = parser.parse_args()
 
@@ -64,6 +82,9 @@ def main() -> None:
             api_keys.prompt_and_save()
         else:
             print("No API key stored.")
+
+    if args.install_all:
+        install_all()
 
 
 if __name__ == "__main__":

--- a/installer/env.py
+++ b/installer/env.py
@@ -1,0 +1,45 @@
+"""Virtual environment management for installer plugins and toolsets."""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+import venv
+
+# Base directory where all virtual environments are stored
+BASE_DIR = Path.home() / ".windows_ai" / "venvs"
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def create_env(name: str) -> Path:
+    """Create (if needed) and return the path to a virtual environment.
+
+    Parameters
+    ----------
+    name:
+        Name of the plugin or toolset.  The environment will be created under
+        ``~/.windows_ai/venvs/<name>``.
+    """
+
+    env_path = BASE_DIR / name
+    if not env_path.exists():
+        venv.EnvBuilder(with_pip=True).create(env_path)
+    return env_path
+
+
+def python_executable(env_path: Path) -> Path:
+    """Return the Python interpreter for ``env_path``."""
+
+    return env_path / ("Scripts" if os.name == "nt" else "bin") / "python"
+
+
+def install_packages(env_path: Path, packages: list[str]) -> None:
+    """Install ``packages`` into the virtual environment at ``env_path``."""
+
+    if not packages:
+        return
+    python = python_executable(env_path)
+    subprocess.check_call([python, "-m", "pip", "install", *packages])
+
+
+__all__ = ["BASE_DIR", "create_env", "python_executable", "install_packages"]

--- a/installer/gui/__init__.py
+++ b/installer/gui/__init__.py
@@ -40,7 +40,7 @@ def main() -> None:
 
     def run_install_all() -> None:
         try:
-            cli.main()
+            cli.install_all()
             messagebox.showinfo("Install", "Install all completed")
         except Exception as exc:  # pragma: no cover - GUI path
             messagebox.showerror("Install", f"Install failed: {exc}")


### PR DESCRIPTION
## Summary
- add `installer.env` for creating venvs and installing packages
- install plugin dependencies via `cli.install_all` and `--install-all` option
- hook GUI "Install All" button to the new workflow and document usage

## Testing
- `pytest`
- `python - <<'PY'
from installer import cli
cli.install_all()
PY`


------
https://chatgpt.com/codex/tasks/task_e_688ccfa4e4d48326bef755e2c889bdec