### PR TITLE
Add Windows PyInstaller packaging script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 __pycache__/
+build/
+dist/
+*.spec

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ This repository provides a high-level outline for experimenting with AI integrat
 For an example of building a chat-centric control center that connects to local or remote language models, see [docs/AI-Control-Center.md](docs/AI-Control-Center.md).
 For an outline of a smart installer that automates hardware detection and AI tool setup, see [docs/Smart-Installer.md](docs/Smart-Installer.md).
 
+## Packaging on Windows
+
+To generate standalone executables on Windows:
+
+1. Install PyInstaller: `pip install pyinstaller`
+2. From the repository root, run `python scripts/package_windows.py cli` to package the command-line interface or `python scripts/package_windows.py gui` for the GUI.
+3. The resulting `.exe` files will be placed in `dist`. Run `dist\windows_ai_cli.exe --help` or double-click `dist\windows_ai_gui.exe` to test.
+
 ## Disclaimer
 
 This repository does not contain any modified Windows binaries or installation media. It only offers guidance for building user-space software that runs on top of a genuine Windows 11 installation. Always follow Microsoft licensing terms and local regulations when customizing or distributing software.

--- a/scripts/package_windows.py
+++ b/scripts/package_windows.py
@@ -1,0 +1,63 @@
+"""Build standalone Windows executables using PyInstaller.
+
+This helper script packages either the command line interface or the
+Tkinter-based GUI into a single-file executable. It relies on
+``pyinstaller`` being installed in the current Python environment.
+
+Usage (from repository root)::
+
+    python scripts/package_windows.py cli
+    python scripts/package_windows.py gui
+
+The generated executable will be placed in the ``dist`` directory.
+Run this script on a Windows machine to create Windows ``.exe`` files.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def build(target: str) -> None:
+    """Run PyInstaller for the requested target."""
+    if target == "cli":
+        entry = ROOT / "installer" / "cli.py"
+        name = "windows_ai_cli"
+        extra = []
+    else:  # gui
+        entry = ROOT / "installer" / "gui" / "__main__.py"
+        name = "windows_ai_gui"
+        extra = ["--noconsole"]
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--onefile",
+        "--name",
+        name,
+        *extra,
+        str(entry),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Package the Windows AI tools")
+    parser.add_argument(
+        "target",
+        choices=["cli", "gui"],
+        help="Which interface to package",
+    )
+    args = parser.parse_args()
+
+    build(args.target)
+    print("\nBuild complete. Check the 'dist' directory for the executable.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/package_windows.py` helper to build single-file CLI or GUI executables with PyInstaller
- document Windows packaging workflow in README
- ignore build artifacts from PyInstaller

## Testing
- `python -m py_compile scripts/package_windows.py`
- `python scripts/package_windows.py cli`

------
https://chatgpt.com/codex/tasks/task_e_688cd25ab2d08326aede5e32808b6878