### PR TITLE
Add pytest tests for system detection and API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ To generate standalone executables on Windows:
 2. From the repository root, run `python scripts/package_windows.py cli` to package the command-line interface or `python scripts/package_windows.py gui` for the GUI.
 3. The resulting `.exe` files will be placed in `dist`. Run `dist\windows_ai_cli.exe --help` or double-click `dist\windows_ai_gui.exe` to test.
 
+## Running Tests
+
+1. Install pytest: `pip install pytest`
+2. Run the tests: `pytest`
+
 ## Disclaimer
 
 This repository does not contain any modified Windows binaries or installation media. It only offers guidance for building user-space software that runs on top of a genuine Windows 11 installation. Always follow Microsoft licensing terms and local regulations when customizing or distributing software.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -ra
+python_files = test_*.py
+testpaths = tests
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,48 @@
+import types
+import pytest
+from installer import api_keys
+
+
+def setup_dummy_keyring(monkeypatch):
+    store = {}
+
+    class DummyKeyring:
+        def set_password(self, service, username, password):
+            store[(service, username)] = password
+
+        def get_password(self, service, username):
+            return store.get((service, username))
+
+        def delete_password(self, service, username):
+            if (service, username) in store:
+                del store[(service, username)]
+            else:
+                raise api_keys.KeyringError("not found")
+
+    dummy = DummyKeyring()
+    monkeypatch.setattr(api_keys, "keyring", dummy)
+    return store
+
+
+def test_save_load_delete_key(monkeypatch):
+    monkeypatch.setattr(api_keys, "_migrate_file_to_keyring", lambda: None)
+    store = setup_dummy_keyring(monkeypatch)
+
+    api_keys.save_key("svc", "secret")
+    assert store[("svc", api_keys._USERNAME)] == "secret"
+    assert api_keys.load_key("svc") == "secret"
+    assert api_keys.delete_key("svc") is True
+    assert api_keys.load_key("svc") is None
+
+
+def test_save_key_no_keyring(monkeypatch):
+    monkeypatch.setattr(api_keys, "keyring", None)
+    monkeypatch.setattr(api_keys, "_migrate_file_to_keyring", lambda: None)
+    with pytest.raises(RuntimeError):
+        api_keys.save_key("svc", "secret")
+
+
+def test_load_key_no_keyring(monkeypatch):
+    monkeypatch.setattr(api_keys, "keyring", None)
+    monkeypatch.setattr(api_keys, "_migrate_file_to_keyring", lambda: None)
+    assert api_keys.load_key("svc") is None

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,0 +1,48 @@
+import sys
+import types
+from installer import system_info
+
+
+def test_detect_system_non_windows(monkeypatch):
+    monkeypatch.setattr(system_info.platform, "platform", lambda: "TestOS")
+    monkeypatch.setattr(system_info.platform, "python_version", lambda: "3.11.0")
+    monkeypatch.setattr(system_info.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(system_info.platform, "system", lambda: "Linux")
+
+    vm = types.SimpleNamespace(total=8 * 1024 ** 3)
+    psutil_mod = types.SimpleNamespace(virtual_memory=lambda: vm)
+    monkeypatch.setitem(sys.modules, "psutil", psutil_mod)
+
+    info = system_info.detect_system()
+    assert info["platform"] == "TestOS"
+    assert info["python_version"] == "3.11.0"
+    assert info["cpu_count"] == 8
+    assert info["memory_gb"] == 8.0
+    assert info["gpu_model"] is None
+    assert info["gpu_vram_gb"] is None
+
+
+def test_detect_system_windows_wmi(monkeypatch):
+    monkeypatch.setattr(system_info.platform, "platform", lambda: "Windows-10")
+    monkeypatch.setattr(system_info.platform, "python_version", lambda: "3.11.0")
+    monkeypatch.setattr(system_info.os, "cpu_count", lambda: 4)
+    monkeypatch.setattr(system_info.platform, "system", lambda: "Windows")
+
+    vm = types.SimpleNamespace(total=16 * 1024 ** 3)
+    psutil_mod = types.SimpleNamespace(virtual_memory=lambda: vm)
+    monkeypatch.setitem(sys.modules, "psutil", psutil_mod)
+
+    class DummyGPU:
+        Name = "Test GPU"
+        AdapterRAM = 4 * 1024 ** 3
+
+    class DummyWMI:
+        def Win32_VideoController(self):
+            return [DummyGPU()]
+
+    wmi_mod = types.SimpleNamespace(WMI=lambda: DummyWMI())
+    monkeypatch.setitem(sys.modules, "wmi", wmi_mod)
+
+    info = system_info.detect_system()
+    assert info["gpu_model"] == "Test GPU"
+    assert info["gpu_vram_gb"] == 4.0


### PR DESCRIPTION
## Summary
- add pytest configuration and documentation
- add tests for system info and api key helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cd6479df88326b11909e7151c0243