### PR TITLE
Add GPU, memory, and disk metrics to system detection

### DIFF
--- a/installer/cli.py
+++ b/installer/cli.py
@@ -1,6 +1,6 @@
 """Command-line entry point for the prototype installer.
 
-The CLI reports basic system information, including GPU model and VRAM when
+The CLI reports basic system information, including GPU name and VRAM when
 available, and optionally prompts the user to store API keys.
 """
 from __future__ import annotations
@@ -51,9 +51,9 @@ def main() -> None:
     info = system_info.detect_system()
     print("Detected system info:")
     print(json.dumps(info, indent=2))
-    if info.get("gpu_model"):
+    if info.get("gpu_name"):
         print(
-            f"GPU: {info['gpu_model']} (VRAM: {info.get('gpu_vram_gb', 'unknown')} GB)"
+            f"GPU: {info['gpu_name']} (VRAM: {info.get('gpu_vram_gb', 'unknown')} GB)"
         )
 
     if args.show_config_dir:

--- a/installer/system_info.py
+++ b/installer/system_info.py
@@ -2,75 +2,142 @@
 
 This module contains helpers that query the running machine for basic
 hardware and software details.  On Windows platforms an effort is made to
-also detect the installed GPU and the amount of dedicated video memory.
+also detect the installed GPU, system memory and disk capacity.
 """
 from __future__ import annotations
 
 import os
 import platform
+import shutil
+import subprocess
 from typing import Any, Dict
 
 
 def detect_system() -> Dict[str, Any]:
     """Return basic information about the host system.
 
-    The function tries to use ``psutil`` for memory metrics and, on Windows
-    hosts, attempts to determine the GPU model and VRAM size.  Optional
-    dependencies are handled gracefully so the script can still run on
-    minimal installations.
+    The function reports CPU, GPU, memory and disk statistics.  On Windows,
+    the :mod:`wmi` module is used when available; other platforms fall back
+    to :mod:`psutil` or shell commands.  Optional dependencies are handled
+    gracefully so the script can still run on minimal installations.
     """
 
     info: Dict[str, Any] = {
         "platform": platform.platform(),
         "python_version": platform.python_version(),
         "cpu_count": os.cpu_count(),
-        "gpu_model": None,
+        "gpu_name": None,
         "gpu_vram_gb": None,
+        "ram_total_gb": None,
+        "ram_free_gb": None,
+        "disk_total_gb": None,
+        "disk_free_gb": None,
     }
 
-    try:
+    try:  # pragma: no cover - psutil optional
         import psutil  # type: ignore
-
-        info["memory_gb"] = round(psutil.virtual_memory().total / (1024 ** 3), 2)
-    except Exception:
-        info["memory_gb"] = None
+    except Exception:  # pragma: no cover - psutil optional
+        psutil = None  # type: ignore
 
     if platform.system() == "Windows":
-        # Try querying GPU details using ``wmi``.
         try:  # pragma: no cover - dependency optional and Windows-specific
             import wmi  # type: ignore
 
-            gpu_info = wmi.WMI().Win32_VideoController()
-            if gpu_info:
-                info["gpu_model"] = gpu_info[0].Name  # type: ignore[attr-defined]
-                ram = getattr(gpu_info[0], "AdapterRAM", None)
-                if ram:
-                    info["gpu_vram_gb"] = round(int(ram) / (1024 ** 3), 2)
-        except Exception:
-            # Fall back to ``pynvml`` which can also report GPU information on
-            # systems with NVIDIA hardware.
-            try:  # pragma: no cover - dependency optional
-                from pynvml import (
-                    nvmlDeviceGetCount,
-                    nvmlDeviceGetHandleByIndex,
-                    nvmlDeviceGetMemoryInfo,
-                    nvmlDeviceGetName,
-                    nvmlInit,
-                    nvmlShutdown,
-                )
-
-                nvmlInit()
-                try:
-                    if nvmlDeviceGetCount() > 0:
-                        handle = nvmlDeviceGetHandleByIndex(0)
-                        info["gpu_model"] = (
-                            nvmlDeviceGetName(handle).decode("utf-8")
-                        )
-                        mem = nvmlDeviceGetMemoryInfo(handle)
-                        info["gpu_vram_gb"] = round(mem.total / (1024 ** 3), 2)
-                finally:
-                    nvmlShutdown()
+            c = wmi.WMI()
+            try:
+                gpu_info = c.Win32_VideoController()
+                if gpu_info:
+                    info["gpu_name"] = gpu_info[0].Name  # type: ignore[attr-defined]
+                    ram = getattr(gpu_info[0], "AdapterRAM", None)
+                    if ram:
+                        info["gpu_vram_gb"] = round(int(ram) / (1024 ** 3), 2)
             except Exception:
                 pass
+
+            try:
+                os_info = c.Win32_OperatingSystem()[0]
+                total_kb = int(getattr(os_info, "TotalVisibleMemorySize", 0))
+                free_kb = int(getattr(os_info, "FreePhysicalMemory", 0))
+                info["ram_total_gb"] = round(total_kb / (1024 ** 2), 2)
+                info["ram_free_gb"] = round(free_kb / (1024 ** 2), 2)
+            except Exception:
+                pass
+
+            try:
+                disks = c.Win32_LogicalDisk(DriveType=3)
+                total = sum(int(d.Size or 0) for d in disks)
+                free = sum(int(d.FreeSpace or 0) for d in disks)
+                if total:
+                    info["disk_total_gb"] = round(total / (1024 ** 3), 2)
+                    info["disk_free_gb"] = round(free / (1024 ** 3), 2)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    if psutil:
+        try:
+            vm = psutil.virtual_memory()
+            info["ram_total_gb"] = info["ram_total_gb"] or round(
+                vm.total / (1024 ** 3), 2
+            )
+            info["ram_free_gb"] = info["ram_free_gb"] or round(
+                vm.available / (1024 ** 3), 2
+            )
+        except Exception:
+            pass
+        try:
+            disk = psutil.disk_usage("/")
+            info["disk_total_gb"] = info["disk_total_gb"] or round(
+                disk.total / (1024 ** 3), 2
+            )
+            info["disk_free_gb"] = info["disk_free_gb"] or round(
+                disk.free / (1024 ** 3), 2
+            )
+        except Exception:
+            pass
+
+    if not info["gpu_name"]:
+        try:  # pragma: no cover - dependency optional
+            if shutil.which("nvidia-smi"):
+                out = subprocess.check_output(
+                    ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+                    stderr=subprocess.DEVNULL,
+                )
+                info["gpu_name"] = out.decode().splitlines()[0].strip()
+        except Exception:
+            pass
+        if not info["gpu_name"] and shutil.which("lspci"):
+            try:
+                out = subprocess.check_output(["lspci"], stderr=subprocess.DEVNULL)
+                for line in out.decode().splitlines():
+                    if "vga" in line.lower():
+                        info["gpu_name"] = line.split(":")[-1].strip()
+                        break
+            except Exception:
+                pass
+
+    if not info["gpu_name"]:
+        try:  # pragma: no cover - dependency optional
+            from pynvml import (
+                nvmlDeviceGetCount,
+                nvmlDeviceGetHandleByIndex,
+                nvmlDeviceGetMemoryInfo,
+                nvmlDeviceGetName,
+                nvmlInit,
+                nvmlShutdown,
+            )
+
+            nvmlInit()
+            try:
+                if nvmlDeviceGetCount() > 0:
+                    handle = nvmlDeviceGetHandleByIndex(0)
+                    info["gpu_name"] = nvmlDeviceGetName(handle).decode("utf-8")
+                    mem = nvmlDeviceGetMemoryInfo(handle)
+                    info["gpu_vram_gb"] = round(mem.total / (1024 ** 3), 2)
+            finally:
+                nvmlShutdown()
+        except Exception:
+            pass
 
     return info

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -9,16 +9,22 @@ def test_detect_system_non_windows(monkeypatch):
     monkeypatch.setattr(system_info.os, "cpu_count", lambda: 8)
     monkeypatch.setattr(system_info.platform, "system", lambda: "Linux")
 
-    vm = types.SimpleNamespace(total=8 * 1024 ** 3)
-    psutil_mod = types.SimpleNamespace(virtual_memory=lambda: vm)
+    vm = types.SimpleNamespace(total=8 * 1024 ** 3, available=2 * 1024 ** 3)
+    disk = types.SimpleNamespace(total=100 * 1024 ** 3, free=20 * 1024 ** 3)
+    psutil_mod = types.SimpleNamespace(
+        virtual_memory=lambda: vm, disk_usage=lambda _: disk
+    )
     monkeypatch.setitem(sys.modules, "psutil", psutil_mod)
 
     info = system_info.detect_system()
     assert info["platform"] == "TestOS"
     assert info["python_version"] == "3.11.0"
     assert info["cpu_count"] == 8
-    assert info["memory_gb"] == 8.0
-    assert info["gpu_model"] is None
+    assert info["ram_total_gb"] == 8.0
+    assert info["ram_free_gb"] == 2.0
+    assert info["disk_total_gb"] == 100.0
+    assert info["disk_free_gb"] == 20.0
+    assert info["gpu_name"] is None
     assert info["gpu_vram_gb"] is None
 
 
@@ -28,21 +34,42 @@ def test_detect_system_windows_wmi(monkeypatch):
     monkeypatch.setattr(system_info.os, "cpu_count", lambda: 4)
     monkeypatch.setattr(system_info.platform, "system", lambda: "Windows")
 
-    vm = types.SimpleNamespace(total=16 * 1024 ** 3)
-    psutil_mod = types.SimpleNamespace(virtual_memory=lambda: vm)
+    vm = types.SimpleNamespace(total=16 * 1024 ** 3, available=8 * 1024 ** 3)
+    disk = types.SimpleNamespace(total=500 * 1024 ** 3, free=200 * 1024 ** 3)
+    psutil_mod = types.SimpleNamespace(
+        virtual_memory=lambda: vm, disk_usage=lambda _: disk
+    )
     monkeypatch.setitem(sys.modules, "psutil", psutil_mod)
 
     class DummyGPU:
         Name = "Test GPU"
         AdapterRAM = 4 * 1024 ** 3
 
+    class DummyOS:
+        TotalVisibleMemorySize = 16 * 1024 * 1024
+        FreePhysicalMemory = 8 * 1024 * 1024
+
+    class DummyDisk:
+        Size = 500 * 1024 ** 3
+        FreeSpace = 200 * 1024 ** 3
+
     class DummyWMI:
         def Win32_VideoController(self):
             return [DummyGPU()]
+
+        def Win32_OperatingSystem(self):
+            return [DummyOS()]
+
+        def Win32_LogicalDisk(self, DriveType=3):  # noqa: N802 - case from WMI
+            return [DummyDisk()]
 
     wmi_mod = types.SimpleNamespace(WMI=lambda: DummyWMI())
     monkeypatch.setitem(sys.modules, "wmi", wmi_mod)
 
     info = system_info.detect_system()
-    assert info["gpu_model"] == "Test GPU"
+    assert info["gpu_name"] == "Test GPU"
     assert info["gpu_vram_gb"] == 4.0
+    assert info["ram_total_gb"] == 16.0
+    assert info["ram_free_gb"] == 8.0
+    assert info["disk_total_gb"] == 500.0
+    assert info["disk_free_gb"] == 200.0


### PR DESCRIPTION
## Summary
- expand system detection to collect GPU name, VRAM, total/free RAM, and disk usage
- query WMI on Windows with psutil or shell fallbacks on other platforms
- update CLI and tests to use the new `gpu_name` field and metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cdede22f883268afef4d56ad1ebf4