### PR TITLE
Add CLI options to list and delete API keys

### DIFF
--- a/installer/api_keys.py
+++ b/installer/api_keys.py
@@ -126,18 +126,26 @@ def save_key(service: str, key: str) -> None:
 def list_keys() -> Dict[str, str]:
     """Return a mapping of stored API keys.
 
-    Only keys stored in the legacy JSON file backend can be listed.  When the
-    system keyring is used, the backend does not offer a portable way to
-    enumerate stored secrets so an empty dictionary is returned.
+    The ``keyring`` package does not expose a cross-platform API for
+    enumerating stored secrets.  To keep behaviour consistent across storage
+    backends we simply delegate to :func:`load_keys`, which relies on the
+    ``WINDOWS_AI_SERVICES`` environment variable to know which services to
+    query from the secure storage.  When using the legacy JSON file backend the
+    contents of that file are returned.
     """
 
+    # ``load_keys`` already handles migration from the legacy file backend and
+    # queries the system keyring when available.
     return load_keys()
 
 
 def delete_key(service: str) -> bool:
     """Remove a stored API key for ``service``.
 
-    Returns ``True`` if a key was removed, otherwise ``False``.
+    The function returns ``True`` when a key existed and was removed.  When the
+    system keyring backend is unavailable the legacy JSON file is used as a
+    fallback.  The migration helper is invoked so callers always interact with
+    the secure storage when possible.
     """
 
     _migrate_file_to_keyring()

--- a/installer/cli.py
+++ b/installer/cli.py
@@ -78,7 +78,25 @@ def main() -> None:
         performed_action = True
 
     if not performed_action:
-        if input("Would you like to add an API key? (y/N) ").strip().lower() == "y":
+        choice = input(
+            "API key options: [l]ist, [d]elete, [a]dd or [n]one? "
+        ).strip().lower()
+
+        if choice == "l":
+            keys = api_keys.list_keys()
+            if keys:
+                print("Stored API keys:")
+                for service in keys:
+                    print(f"- {service}")
+            else:
+                print("No API keys stored.")
+        elif choice == "d":
+            service = input("Service to delete: ").strip()
+            if api_keys.delete_key(service):
+                print(f"Deleted key for {service}")
+            else:
+                print(f"No key stored for {service}")
+        elif choice in {"a", "y"}:  # support legacy 'y' for yes to add
             api_keys.prompt_and_save()
         else:
             print("No API key stored.")


### PR DESCRIPTION
## Summary
- document list_keys and delete_key for secure keyring storage
- allow interactive listing and deletion of API keys via CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce6f8faa883269da969a0719084f8