### PR TITLE
feat: manage plugin environments

### DIFF
--- a/docs/Installer-Plugins.md
+++ b/docs/Installer-Plugins.md
@@ -17,7 +17,8 @@ Plugins are discovered in two ways:
 ## Writing a Plugin
 
 A plugin is simply a callable that accepts a `PluginRegistry` instance. Most
-modules expose a `register(registry)` function:
+modules expose a `register(registry)` function.  Dependencies are recorded per
+plugin so the installer can create an isolated environment for each one:
 
 ```python
 # my_plugin.py
@@ -42,7 +43,7 @@ Use :func:`discover_plugins` to load all available plugins:
 from installer.plugins import discover_plugins
 
 registry = discover_plugins("./local_plugins")
-print(registry.dependencies)
+print(registry.dependencies)  # mapping of plugin name -> set(dependencies)
 print(registry.ui_components)
 ```
 

--- a/docs/Smart-Installer.md
+++ b/docs/Smart-Installer.md
@@ -39,8 +39,9 @@ This document sketches a design for an automated installer that sets up an AI ec
 
 Plugins and toolsets are installed into isolated Python environments managed by
 ``installer.env``. Each plugin can request dependencies and the installer will
-create a dedicated ``venv`` under ``~/.windows_ai/venvs/<name>`` to avoid
-package conflicts.
+create a dedicated environment under ``~/.windows_ai/venvs/<name>`` using
+``venv`` or Conda.  The helper records created environments in
+``~/.windows_ai/envs.json`` so the AI Control Center can activate them later.
 
 ```python
 from installer import env

--- a/installer/cli.py
+++ b/installer/cli.py
@@ -15,13 +15,16 @@ def install_all() -> None:
     """Discover plugins and install their requested dependencies."""
 
     registry = plugins.discover_plugins()
-    deps = sorted(registry.dependencies)
-    if not deps:
+    if not registry.dependencies:
         print("No plugin dependencies to install.")
         return
-    env_path = env.create_env("plugins")
-    env.install_packages(env_path, deps)
-    print(f"Installed {len(deps)} packages into {env_path}")
+
+    for plugin_name, deps in sorted(registry.dependencies.items()):
+        env_path = env.create_env(plugin_name)
+        env.install_packages(env_path, sorted(deps))
+        print(
+            f"Installed {len(deps)} packages for {plugin_name} into {env_path}"
+        )
 
 
 def main() -> None:

--- a/installer/env.py
+++ b/installer/env.py
@@ -1,29 +1,72 @@
-"""Virtual environment management for installer plugins and toolsets."""
+"""Virtual environment management for installer plugins and toolsets.
+
+This module abstracts creation of isolated Python environments using either the
+built-in ``venv`` module or ``conda`` when available.  Paths to created
+environments are recorded so the AI Control Center can later activate them.
+"""
+
 from __future__ import annotations
 
+import json
 import os
 import subprocess
-from pathlib import Path
 import venv
+from pathlib import Path
+from typing import Iterable
+import shutil
 
-# Base directory where all virtual environments are stored
-BASE_DIR = Path.home() / ".windows_ai" / "venvs"
+# Base configuration and environment directories
+CONFIG_DIR = Path.home() / ".windows_ai"
+BASE_DIR = CONFIG_DIR / "venvs"
+ENV_RECORD_FILE = CONFIG_DIR / "envs.json"
 BASE_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def create_env(name: str) -> Path:
-    """Create (if needed) and return the path to a virtual environment.
+def _use_conda() -> bool:
+    """Return ``True`` if conda environments should be used."""
+
+    env_var = os.getenv("WINDOWS_AI_USE_CONDA")
+    if env_var is not None:
+        return env_var.lower() not in {"0", "false", "no"}
+    return shutil.which("conda") is not None
+
+
+def _record_env_path(name: str, path: Path) -> None:
+    """Persist the mapping between ``name`` and ``path``."""
+
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    data: dict[str, str] = {}
+    if ENV_RECORD_FILE.exists():
+        try:
+            data = json.loads(ENV_RECORD_FILE.read_text())
+        except Exception:
+            data = {}
+    data[name] = str(path)
+    ENV_RECORD_FILE.write_text(json.dumps(data, indent=2))
+
+
+def create_env(name: str, backend: str | None = None) -> Path:
+    """Create (if needed) and return the path to an isolated environment.
 
     Parameters
     ----------
     name:
         Name of the plugin or toolset.  The environment will be created under
         ``~/.windows_ai/venvs/<name>``.
+    backend:
+        Optional backend selector.  Accepts ``"venv"`` or ``"conda"``.  When
+        omitted the function automatically chooses ``conda`` if
+        ``WINDOWS_AI_USE_CONDA`` is set or the ``conda`` command is available.
     """
 
     env_path = BASE_DIR / name
+    backend = backend or ("conda" if _use_conda() else "venv")
     if not env_path.exists():
-        venv.EnvBuilder(with_pip=True).create(env_path)
+        if backend == "conda":
+            subprocess.check_call(["conda", "create", "-y", "-p", str(env_path), "python"])
+        else:
+            venv.EnvBuilder(with_pip=True).create(env_path)
+    _record_env_path(name, env_path)
     return env_path
 
 
@@ -33,13 +76,33 @@ def python_executable(env_path: Path) -> Path:
     return env_path / ("Scripts" if os.name == "nt" else "bin") / "python"
 
 
-def install_packages(env_path: Path, packages: list[str]) -> None:
-    """Install ``packages`` into the virtual environment at ``env_path``."""
+def install_packages(env_path: Path, packages: Iterable[str]) -> None:
+    """Install ``packages`` into the environment at ``env_path``."""
 
+    packages = list(packages)
     if not packages:
         return
     python = python_executable(env_path)
     subprocess.check_call([python, "-m", "pip", "install", *packages])
 
 
-__all__ = ["BASE_DIR", "create_env", "python_executable", "install_packages"]
+def load_recorded_envs() -> dict[str, str]:
+    """Return the mapping of recorded environments."""
+
+    if not ENV_RECORD_FILE.exists():
+        return {}
+    try:
+        return json.loads(ENV_RECORD_FILE.read_text())
+    except Exception:
+        return {}
+
+
+__all__ = [
+    "CONFIG_DIR",
+    "BASE_DIR",
+    "ENV_RECORD_FILE",
+    "create_env",
+    "python_executable",
+    "install_packages",
+    "load_recorded_envs",
+]

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,35 @@
+import json
+
+from installer import env
+
+
+def test_create_env_records_path(tmp_path, monkeypatch):
+    # Redirect configuration paths to a temporary directory
+    config_dir = tmp_path / "config"
+    monkeypatch.setattr(env, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(env, "BASE_DIR", config_dir / "venvs")
+    monkeypatch.setattr(env, "ENV_RECORD_FILE", config_dir / "envs.json")
+    monkeypatch.setattr(env, "_use_conda", lambda: False)
+
+    env_path = env.create_env("sample-plugin")
+    assert env_path.exists()
+
+    data = json.loads(env.ENV_RECORD_FILE.read_text())
+    assert data["sample-plugin"] == str(env_path)
+
+
+def test_discover_plugins_groups_dependencies(tmp_path):
+    # Create a temporary plugin
+    plugin_file = tmp_path / "my_plugin.py"
+    plugin_file.write_text(
+        """
+def register(registry):
+    registry.add_dependency('demo-package')
+"""
+    )
+
+    from installer import plugins
+
+    registry = plugins.discover_plugins(tmp_path)
+    assert registry.dependencies == {"my_plugin": {"demo-package"}}
+


### PR DESCRIPTION
## Summary
- add `installer.env` helper that can create `venv` or Conda envs and records their locations
- track plugin dependencies by plugin and create dedicated envs during installs
- document plugin environments and add tests for env creation and discovery

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cf31e22c88326b1d6595d859cf672