### PR TITLE
Add API key listing test and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest
+

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -24,14 +24,17 @@ def setup_dummy_keyring(monkeypatch):
     return store
 
 
-def test_save_load_delete_key(monkeypatch):
+def test_save_list_load_delete_key(monkeypatch):
     monkeypatch.setattr(api_keys, "_migrate_file_to_keyring", lambda: None)
     store = setup_dummy_keyring(monkeypatch)
+    monkeypatch.setenv("WINDOWS_AI_SERVICES", "svc")
 
     api_keys.save_key("svc", "secret")
     assert store[("svc", api_keys._USERNAME)] == "secret"
+    assert api_keys.list_keys() == {"svc": "secret"}
     assert api_keys.load_key("svc") == "secret"
     assert api_keys.delete_key("svc") is True
+    assert api_keys.list_keys() == {}
     assert api_keys.load_key("svc") is None
 
 


### PR DESCRIPTION
## Summary
- extend API key tests to cover list operations and ensure save/delete work
- add GitHub Actions workflow running pytest on pushes and PRs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688cfa0e40108326a209c0aa922520ac