### PR TITLE
Add model backend selector with GUI override option

### DIFF
--- a/installer/gui.py
+++ b/installer/gui.py
@@ -4,7 +4,7 @@ import threading
 import tkinter as tk
 from tkinter import messagebox, simpledialog, ttk
 
-from . import api_keys, env, plugins, system_info
+from . import api_keys, env, model_selector, plugins, system_info
 
 
 class InstallerGUI:
@@ -48,6 +48,27 @@ class InstallerGUI:
                 padx=5, pady=5
             )
 
+        # Backend selection
+        backend_frame = tk.LabelFrame(self.root, text="Model Backend")
+        backend_frame.pack(fill="x", padx=10, pady=5)
+        recommended = model_selector.select_backend("default", {})
+        self.backend_var = tk.StringVar(value=recommended)
+        ttk.Radiobutton(
+            backend_frame,
+            text="Use Local Models",
+            value="local",
+            variable=self.backend_var,
+        ).pack(anchor="w")
+        ttk.Radiobutton(
+            backend_frame,
+            text="Use Remote APIs",
+            value="remote",
+            variable=self.backend_var,
+        ).pack(anchor="w")
+        tk.Label(
+            backend_frame, text=f"Recommended: {recommended}", justify="left"
+        ).pack(anchor="w", padx=5)
+
         # Buttons
         button_frame = tk.Frame(self.root)
         button_frame.pack(pady=10)
@@ -89,6 +110,10 @@ class InstallerGUI:
         if not selected_plugins:
             messagebox.showinfo("Install", "No components selected")
             return
+
+        # Allow user override of the model backend
+        backend = self.backend_var.get()
+        print(f"Backend chosen: {backend}")
 
         # Prompt for API key before installation
         service = simpledialog.askstring(

--- a/installer/model_selector.py
+++ b/installer/model_selector.py
@@ -1,0 +1,48 @@
+"""Model backend selection utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from . import system_info
+
+
+def select_backend(task: str, specs: Dict[str, Any]) -> str:
+    """Choose between a local model and a remote API for ``task``.
+
+    Parameters
+    ----------
+    task:
+        Identifier for the task requesting a model backend.  Currently unused
+        but reserved for future heuristics.
+    specs:
+        Hardware requirements for running the task locally.  Recognised keys are
+        ``requires_gpu`` (bool), ``min_vram_gb`` (float) and ``min_ram_gb``
+        (float).  Missing keys are treated as no requirement.
+
+    Returns
+    -------
+    str
+        ``"local"`` if the system appears to meet the requirements, otherwise
+        ``"remote"``.
+    """
+
+    info = system_info.detect_system()
+
+    def meets(value: float | None, requirement: float | None) -> bool:
+        if requirement is None:
+            return True
+        if value is None:
+            return False
+        return value >= requirement
+
+    if specs.get("requires_gpu") and not info.get("gpu_name"):
+        return "remote"
+
+    if not meets(info.get("gpu_vram_gb"), specs.get("min_vram_gb")):
+        return "remote"
+
+    if not meets(info.get("ram_total_gb"), specs.get("min_ram_gb")):
+        return "remote"
+
+    return "local"

--- a/tests/test_model_selector.py
+++ b/tests/test_model_selector.py
@@ -1,0 +1,31 @@
+from installer import model_selector
+
+
+def test_select_backend_local(monkeypatch):
+    def fake_detect():
+        return {"gpu_name": "RTX", "gpu_vram_gb": 8, "ram_total_gb": 16}
+
+    monkeypatch.setattr(model_selector.system_info, "detect_system", fake_detect)
+
+    specs = {"requires_gpu": True, "min_vram_gb": 4, "min_ram_gb": 8}
+    assert model_selector.select_backend("text", specs) == "local"
+
+
+def test_select_backend_remote_no_gpu(monkeypatch):
+    def fake_detect():
+        return {"gpu_name": None, "gpu_vram_gb": None, "ram_total_gb": 16}
+
+    monkeypatch.setattr(model_selector.system_info, "detect_system", fake_detect)
+
+    specs = {"requires_gpu": True}
+    assert model_selector.select_backend("text", specs) == "remote"
+
+
+def test_select_backend_remote_low_ram(monkeypatch):
+    def fake_detect():
+        return {"gpu_name": "RTX", "gpu_vram_gb": 8, "ram_total_gb": 4}
+
+    monkeypatch.setattr(model_selector.system_info, "detect_system", fake_detect)
+
+    specs = {"min_ram_gb": 8}
+    assert model_selector.select_backend("text", specs) == "remote"


### PR DESCRIPTION
## Summary
- add `model_selector.select_backend` to choose local vs remote backends based on system specs
- integrate backend selector into installer GUI with user override controls
- cover selection logic with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d8e10152c8326a79e7d44b5a5d9a4