### PR TITLE
Add domain processing stubs

### DIFF
--- a/domains/__init__.py
+++ b/domains/__init__.py
@@ -1,0 +1,11 @@
+"""Domain-specific processing pipelines.
+
+This package contains modular stubs for various AI domains. Each module exposes
+functions that coordinate routing through local models or external APIs.
+"""
+
+__all__ = [
+    "natural_language_processing",
+    "computer_vision",
+    "audio_processing",
+]

--- a/domains/audio_processing.py
+++ b/domains/audio_processing.py
@@ -1,0 +1,48 @@
+"""Utilities for audio processing tasks.
+
+The functions below illustrate how audio-related operations might choose between
+local processing and external API calls.
+"""
+
+from __future__ import annotations
+from typing import Any, Dict
+
+
+def input_processor(audio: Any) -> Any:
+    """Prepare ``audio`` data for downstream consumption.
+
+    Implementations should handle resampling, noise reduction, and deciding
+    whether to use on-device audio models or route data to APIs.
+    """
+
+    return audio
+
+
+def task_planner(processed_audio: Any) -> Dict[str, Any]:
+    """Determine the audio processing steps to execute.
+
+    The planner identifies tasks suited for local models and those that require
+    remote services.
+    """
+
+    return {"plan": []}
+
+
+def executor(plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute the planned audio processing steps.
+
+    Each step should be run using local capabilities or delegated to an external
+    API when appropriate.
+    """
+
+    return {"results": []}
+
+
+def result_aggregator(results: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge outputs from audio processing tasks.
+
+    This function should compile results from both local models and APIs into a
+    coherent structure.
+    """
+
+    return results

--- a/domains/computer_vision.py
+++ b/domains/computer_vision.py
@@ -1,0 +1,48 @@
+"""Utilities for computer vision tasks.
+
+These stubs demonstrate how vision-related functions could route operations
+through local models or remote APIs.
+"""
+
+from __future__ import annotations
+from typing import Any, Dict
+
+
+def input_processor(image: Any) -> Any:
+    """Prepare ``image`` data for model or API consumption.
+
+    Real implementations should perform tasks such as resizing, normalization,
+    and selecting whether to use local vision models or call external services.
+    """
+
+    return image
+
+
+def task_planner(processed_image: Any) -> Dict[str, Any]:
+    """Plan the sequence of vision tasks to perform.
+
+    The planner determines which components are best handled locally versus
+    those requiring API calls.
+    """
+
+    return {"plan": []}
+
+
+def executor(plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute vision tasks described in ``plan``.
+
+    Each step in the plan should be run on local models or translated into API
+    requests when necessary.
+    """
+
+    return {"results": []}
+
+
+def result_aggregator(results: Dict[str, Any]) -> Dict[str, Any]:
+    """Combine results from the executed vision tasks.
+
+    This function should merge outputs from various local and remote sources
+    into a unified representation.
+    """
+
+    return results

--- a/domains/natural_language_processing.py
+++ b/domains/natural_language_processing.py
@@ -1,0 +1,49 @@
+"""Utilities for natural language processing tasks.
+
+Each function serves as a placeholder for routing NLP-related operations through
+local models or remote APIs.
+"""
+
+from __future__ import annotations
+from typing import Any, Dict
+
+
+def input_processor(raw_text: str) -> str:
+    """Preprocess ``raw_text`` before it is passed to models or APIs.
+
+    Implementations should handle tokenization, normalization, and determine
+    whether to use on-device NLP models or forward the request to an external
+    service.
+    """
+
+    return raw_text
+
+
+def task_planner(processed_text: str) -> Dict[str, Any]:
+    """Plan the NLP task pipeline based on ``processed_text``.
+
+    The planner decides which local models or APIs are required to accomplish
+    the requested NLP task.
+    """
+
+    return {"plan": []}
+
+
+def executor(plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute the planned NLP tasks.
+
+    Each step in ``plan`` should be dispatched either to local models or to
+    external NLP services when necessary.
+    """
+
+    return {"results": []}
+
+
+def result_aggregator(results: Dict[str, Any]) -> Dict[str, Any]:
+    """Combine outputs from executed NLP tasks.
+
+    Aggregated results should unify responses from local models and APIs into a
+    single structured output.
+    """
+
+    return results


### PR DESCRIPTION
## Summary
- add `domains` package with NLP, vision, and audio modules
- stub out processors, planners, executors, and aggregators with guidance for routing via local models or APIs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d9396dbec832696e7eb2a54a7e88d