### PR TITLE
chore: expand gitignore for logs and virtual envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,23 @@
+# Byte-compiled / cache
 __pycache__/
+*.py[cod]
+
+# Logs
+*.log
+AI/Logs/
+
+# Virtual environments
+.venv/
+
+# Installer secrets
+installer/keys.json
+
+# Build artifacts
 build/
 dist/
 *.spec
+
+# Test & coverage
+.pytest_cache/
+.mypy_cache/
+.coverage


### PR DESCRIPTION
## Summary
- ignore log files and runtime logs directory
- keep installer secrets and virtual environments out of version control
- exclude common build, test and coverage artifacts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d94f08888832692357965cac2e95c