### PR TITLE
feat: show plugin descriptions in GUI

### DIFF
--- a/installer/plugins/manager.py
+++ b/installer/plugins/manager.py
@@ -72,8 +72,12 @@ class PluginManager:
         for plugin in self.plugins:
             var = tk.BooleanVar(value=False)
             selections[plugin.name] = var
-            label = f"{plugin.name} ({'Paid' if plugin.paid else 'Free'})"
-            ttk.Checkbutton(frame, text=label, variable=var).pack(anchor="w")
+            label = (
+                f"{plugin.name} ({'Paid' if plugin.paid else 'Free'})\n{plugin.description}"
+            )
+            ttk.Checkbutton(
+                frame, text=label, variable=var, justify="left"
+            ).pack(anchor="w", fill="x", padx=5, pady=2)
 
         def _install() -> None:
             chosen = [p for p in self.plugins if selections[p.name].get()]


### PR DESCRIPTION
## Summary
- Display plugin descriptions alongside free/paid status in the plugin manager GUI
- Catalog already lists sample plugins like LangChain, n8n, and Warp Terminal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e391b641483268668ea521b4db461