### PR TITLE
Refactor model metadata with host mapping

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,15 +7,17 @@ def test_compatible_models(monkeypatch):
     dummy = {
         "cpu": models.ModelInfo(
             name="cpu",
-            url="http://example.com/cpu.bin",
+            filename="cpu.bin",
             checksum="",
+            host="default",
             requires_gpu=False,
             min_ram_gb=4,
         ),
         "gpu": models.ModelInfo(
             name="gpu",
-            url="http://example.com/gpu.bin",
+            filename="gpu.bin",
             checksum="",
+            host="default",
             requires_gpu=True,
             min_vram_gb=8,
         ),
@@ -24,6 +26,17 @@ def test_compatible_models(monkeypatch):
     info = {"gpu_name": None, "ram_total_gb": 16, "gpu_vram_gb": None}
     compatibles = models.compatible_models(info)
     assert [m.name for m in compatibles] == ["cpu"]
+
+
+def test_model_url(monkeypatch):
+    monkeypatch.setitem(models.MODEL_HOSTS, "test", "https://example.org/base")
+    info = models.ModelInfo(
+        name="dummy",
+        filename="dummy.bin",
+        checksum="",
+        host="test",
+    )
+    assert info.url == "https://example.org/base/dummy.bin"
 
 
 def test_verify_checksum(tmp_path):


### PR DESCRIPTION
## Summary
- encapsulate model hosts and filenames in a new `ModelInfo` structure
- build download URLs dynamically from host mappings and verify checksums
- test URL resolution, compatibility filtering and checksum validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e49683e8083269ec45e9146eb9401