### PR TITLE
Secure API key storage with Windows backend

### DIFF
--- a/installer/api_keys.py
+++ b/installer/api_keys.py
@@ -1,17 +1,42 @@
-"""Simple API key storage helper backed by the system keyring.
+"""API key storage helpers with Windows-specific secure backend.
 
-API keys were previously stored in a JSON file under ``~/.windows_ai``.  On
-import, this module migrates any existing keys from that file into the system
-keyring (Windows Credential Manager on Windows).  After a successful
-migration the legacy file is removed and all future reads and writes interact
-solely with the keyring so secrets are no longer kept on disk.
+The module exposes a small API for persisting secrets used by the
+application.  When running on Windows the preferred backend is the
+Windows Credential Manager accessed through ``win32cred``.  If that
+module is unavailable the ``keyring`` package is used as a generic
+fallback.  For non-Windows platforms where no keyring backend is
+available an encrypted JSON file stored under ``~/.windows_ai`` is used.
+
+The encrypted file backend relies on ``cryptography.fernet``.  When that
+package is missing attempts to save a key will raise ``RuntimeError``.
+This keeps plaintext API keys off disk while still permitting basic
+functionality in minimal environments.
 """
+
 from __future__ import annotations
 
 import json
 import os
 from getpass import getpass
 from typing import Dict, Optional
+
+from .logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Optional backend imports
+# ---------------------------------------------------------------------------
+
+IS_WINDOWS = os.name == "nt"
+
+try:  # pragma: no cover - windows specific import
+    if IS_WINDOWS:
+        import win32cred  # type: ignore
+    else:  # pragma: no cover - executed only on Windows
+        win32cred = None  # type: ignore[assignment]
+except Exception:  # pragma: no cover - win32cred not installed
+    win32cred = None  # type: ignore[assignment]
 
 try:
     import keyring
@@ -20,102 +45,187 @@ except Exception:  # pragma: no cover - keyring not installed
     keyring = None  # type: ignore[assignment]
     KeyringError = Exception  # type: ignore[misc]
 
-from .logging_config import get_logger
+try:  # pragma: no cover - optional dependency
+    from cryptography.fernet import Fernet
+except Exception:  # pragma: no cover - cryptography not installed
+    Fernet = None  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Paths used by the file based backend
+# ---------------------------------------------------------------------------
 
 CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".windows_ai")
-KEYS_FILE = os.path.join(CONFIG_DIR, "keys.json")
+ENC_FILE = os.path.join(CONFIG_DIR, "keys.enc")
+FERNET_KEY_FILE = os.path.join(CONFIG_DIR, "fernet.key")
 _USERNAME = "api_key"
 
-logger = get_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# Helper functions for the encrypted file backend
+# ---------------------------------------------------------------------------
 
-def _migrate_file_to_keyring() -> None:
-    """Migrate keys from the legacy JSON file into the system keyring."""
-
-    if keyring is None or not os.path.exists(KEYS_FILE):
-        return
+def _ensure_config_dir() -> None:
+    """Create the configuration directory when needed."""
 
     try:
-        with open(KEYS_FILE, "r", encoding="utf-8") as f:
-            data: Dict[str, str] = json.load(f)
-    except Exception:
-        logger.exception("Failed to read legacy keys file %s", KEYS_FILE)
-        return
+        os.makedirs(CONFIG_DIR, exist_ok=True)
+    except OSError:  # pragma: no cover - unlikely failure
+        logger.exception("Failed to create config directory %s", CONFIG_DIR)
 
-    for service, value in data.items():
+
+def _load_fernet() -> Optional["Fernet"]:
+    """Return a ``Fernet`` instance initialised with the stored key."""
+
+    if Fernet is None:
+        return None
+
+    _ensure_config_dir()
+
+    key: bytes
+    if not os.path.exists(FERNET_KEY_FILE):
+        key = Fernet.generate_key()
         try:
-            keyring.set_password(service, _USERNAME, value)
-        except Exception:
-            # If any write fails keep the file so migration can retry later.
-            logger.exception(
-                "Failed to store key for %s in system keyring", service
-            )
-            return
+            with open(FERNET_KEY_FILE, "wb") as kf:
+                os.chmod(FERNET_KEY_FILE, 0o600)
+                kf.write(key)
+        except OSError:  # pragma: no cover - filesystem errors
+            logger.exception("Failed to write key file %s", FERNET_KEY_FILE)
+            return None
+    else:
+        try:
+            with open(FERNET_KEY_FILE, "rb") as kf:
+                key = kf.read()
+        except OSError:  # pragma: no cover - filesystem errors
+            logger.exception("Failed to read key file %s", FERNET_KEY_FILE)
+            return None
 
     try:
-        os.remove(KEYS_FILE)
-        if not os.listdir(CONFIG_DIR):
-            os.rmdir(CONFIG_DIR)
-    except OSError:
-        logger.exception("Failed to clean up legacy key files")
+        return Fernet(key)
+    except Exception:  # pragma: no cover - invalid key
+        logger.exception("Failed to initialise Fernet with key file")
+        return None
 
 
-# Run migration as soon as the module is imported.
-_migrate_file_to_keyring()
+def _load_file_store() -> Dict[str, str]:
+    """Decrypt the on-disk store and return the mapping."""
 
+    fernet = _load_fernet()
+    if fernet is None or not os.path.exists(ENC_FILE):
+        return {}
+
+    try:
+        with open(ENC_FILE, "rb") as f:
+            data = f.read()
+        decrypted = fernet.decrypt(data)
+        return json.loads(decrypted.decode("utf-8"))
+    except Exception:  # pragma: no cover - corrupt file or key
+        logger.exception("Failed to read encrypted keys file")
+        return {}
+
+
+def _save_file_store(store: Dict[str, str]) -> None:
+    """Write the mapping to disk using the encrypted backend."""
+
+    fernet = _load_fernet()
+    if fernet is None:
+        raise RuntimeError("Encryption backend not available")
+
+    data = json.dumps(store).encode("utf-8")
+    encrypted = fernet.encrypt(data)
+
+    _ensure_config_dir()
+    try:
+        with open(ENC_FILE, "wb") as f:
+            os.chmod(ENC_FILE, 0o600)
+            f.write(encrypted)
+    except OSError:  # pragma: no cover - filesystem errors
+        logger.exception("Failed to write encrypted keys file")
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 def load_key(service: str) -> Optional[str]:
     """Retrieve a stored API key for ``service``.
 
-    Returns ``None`` if the key is not set or no suitable keyring backend is
-    available.
+    Returns ``None`` when the key is unavailable or no backend can provide
+    it.
     """
 
-    _migrate_file_to_keyring()
+    if IS_WINDOWS and win32cred is not None:
+        try:  # pragma: no cover - executed only on Windows
+            cred = win32cred.CredRead(service, win32cred.CRED_TYPE_GENERIC, 0)
+            blob = cred.get("CredentialBlob", b"")
+            if isinstance(blob, bytes):
+                return blob.decode("utf-16-le")
+            return blob
+        except Exception:  # pragma: no cover - win32cred errors
+            logger.exception("Failed to read key for %s", service)
+            return None
 
-    if keyring is None:
-        return None
+    if keyring is not None:
+        try:
+            return keyring.get_password(service, _USERNAME)
+        except KeyringError:
+            logger.exception("Failed to read key for %s from keyring", service)
+            return None
 
-    try:
-        return keyring.get_password(service, _USERNAME)
-    except KeyringError:
-        logger.exception("Failed to load key for %s", service)
-        return None
+    store = _load_file_store()
+    return store.get(service)
 
 
 def save_key(service: str, key: str) -> None:
-    """Persist a new API key using the system keyring."""
+    """Persist an API key using the most secure backend available."""
 
-    _migrate_file_to_keyring()
+    if IS_WINDOWS and win32cred is not None:
+        try:  # pragma: no cover - executed only on Windows
+            credential = {
+                "Type": win32cred.CRED_TYPE_GENERIC,
+                "TargetName": service,
+                "UserName": _USERNAME,
+                "CredentialBlob": key.encode("utf-16-le"),
+                "Persist": win32cred.CRED_PERSIST_LOCAL_MACHINE,
+            }
+            win32cred.CredWrite(credential, 0)
+            return
+        except Exception:  # pragma: no cover - win32cred errors
+            logger.exception("Failed to write key for %s", service)
+            raise
 
-    if keyring is None:
-        raise RuntimeError("No system keyring backend available")
+    if keyring is not None:
+        try:
+            keyring.set_password(service, _USERNAME, key)
+            return
+        except Exception:
+            logger.exception("Failed to write key for %s to keyring", service)
+            raise
 
-    try:
-        keyring.set_password(service, _USERNAME, key)
-    except Exception:
-        logger.exception("Failed to save key for %s", service)
-        raise
+    store = _load_file_store()
+    store[service] = key
+    _save_file_store(store)
 
 
 def list_keys() -> Dict[str, str]:
-    """Return a mapping of stored API keys from the system keyring.
+    """Return a mapping of stored API keys.
 
-    Because the ``keyring`` package does not expose a cross-platform API for
-    enumerating stored secrets, callers can provide a comma-separated list of
-    services through the ``WINDOWS_AI_SERVICES`` environment variable.  Any
-    keys found for those services will be returned.  When the keyring backend
-    is unavailable an empty mapping is returned.
+    Because not all backends support enumeration, callers can provide a
+    comma-separated list of services through the ``WINDOWS_AI_SERVICES``
+    environment variable.  Keys for those services will be returned when
+    available.
     """
-
-    _migrate_file_to_keyring()
-
-    if keyring is None:
-        return {}
 
     services_env = os.getenv("WINDOWS_AI_SERVICES", "")
     services = [s.strip() for s in services_env.split(",") if s.strip()]
     keys: Dict[str, str] = {}
+
+    if not services:
+        if keyring is None and not (IS_WINDOWS and win32cred is not None):
+            # File backend can enumerate all stored services
+            return _load_file_store()
+        return {}
 
     for svc in services:
         value = load_key(svc)
@@ -126,29 +236,34 @@ def list_keys() -> Dict[str, str]:
 
 
 def delete_key(service: str) -> bool:
-    """Remove a stored API key for ``service``.
+    """Remove a stored API key for ``service``."""
 
-    The function returns ``True`` when a key existed and was removed.  If the
-    system keyring backend is unavailable ``False`` is returned.  The migration
-    helper is invoked so callers always interact with the secure storage when
-    possible.
-    """
+    if IS_WINDOWS and win32cred is not None:
+        try:  # pragma: no cover - executed only on Windows
+            win32cred.CredDelete(service, win32cred.CRED_TYPE_GENERIC, 0)
+            return True
+        except Exception:  # pragma: no cover - win32cred errors
+            logger.exception("Failed to delete key for %s", service)
+            return False
 
-    _migrate_file_to_keyring()
+    if keyring is not None:
+        try:
+            keyring.delete_password(service, _USERNAME)
+            return True
+        except KeyringError:
+            logger.exception("Failed to delete key for %s from keyring", service)
+            return False
 
-    if keyring is None:
-        return False
-
-    try:
-        keyring.delete_password(service, _USERNAME)
-        return True
-    except KeyringError:
-        logger.exception("Failed to delete key for %s", service)
-        return False
+    store = _load_file_store()
+    existed = service in store
+    if existed:
+        del store[service]
+        _save_file_store(store)
+    return existed
 
 
 def prompt_and_save() -> None:
-    """Interactively ask the user for an API key and save it."""
+    """Interactively prompt the user for an API key and save it."""
 
     try:
         service = input("Service name: ")
@@ -156,9 +271,27 @@ def prompt_and_save() -> None:
     except Exception:
         logger.exception("Failed to read API key input")
         return
+
     try:
         save_key(service, key)
     except Exception:
         logger.exception("Failed to save key for %s", service)
         return
-    print(f"Saved {service} key to the system keyring")
+
+    print(f"Saved {service} key")
+
+
+__all__ = [
+    "load_key",
+    "save_key",
+    "list_keys",
+    "delete_key",
+    "prompt_and_save",
+    "CONFIG_DIR",
+    "ENC_FILE",
+    "FERNET_KEY_FILE",
+    "keyring",
+    "KeyringError",
+    "win32cred",
+]
+

--- a/installer/gui_installer.py
+++ b/installer/gui_installer.py
@@ -36,6 +36,9 @@ class GUIInstaller:
         ttk.Button(button_frame, text="Add API Key", command=self.add_api_key).pack(
             side=tk.LEFT, padx=5
         )
+        ttk.Button(button_frame, text="Check API Key", command=self.check_api_key).pack(
+            side=tk.LEFT, padx=5
+        )
 
         self.info = tk.Text(self.root, width=60, height=10, state="disabled")
         self.info.pack(padx=10, pady=5)
@@ -85,6 +88,24 @@ class GUIInstaller:
             messagebox.showinfo("API Key", f"Saved key for {service}")
         except Exception as exc:  # pragma: no cover - GUI path
             messagebox.showerror("API Key", str(exc))
+        finally:
+            self.progress.stop()
+            self.progress.config(mode="determinate", value=0)
+
+    def check_api_key(self) -> None:
+        """Verify whether a stored key exists for a service."""
+
+        service = simpledialog.askstring("API Key", "Service name:", parent=self.root)
+        if not service:
+            return
+        self.progress.config(mode="indeterminate")
+        self.progress.start()
+        try:
+            key = api_keys.load_key(service)
+            if key:
+                messagebox.showinfo("API Key", f"Key stored for {service}")
+            else:
+                messagebox.showinfo("API Key", f"No key stored for {service}")
         finally:
             self.progress.stop()
             self.progress.config(mode="determinate", value=0)

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,9 +1,10 @@
-import types
 import pytest
 from installer import api_keys
 
 
 def setup_dummy_keyring(monkeypatch):
+    """Install a dummy in-memory keyring backend."""
+
     store = {}
 
     class DummyKeyring:
@@ -21,11 +22,11 @@ def setup_dummy_keyring(monkeypatch):
 
     dummy = DummyKeyring()
     monkeypatch.setattr(api_keys, "keyring", dummy)
+    monkeypatch.setattr(api_keys, "win32cred", None)
     return store
 
 
-def test_save_list_load_delete_key(monkeypatch):
-    monkeypatch.setattr(api_keys, "_migrate_file_to_keyring", lambda: None)
+def test_save_list_load_delete_with_keyring(monkeypatch):
     store = setup_dummy_keyring(monkeypatch)
     monkeypatch.setenv("WINDOWS_AI_SERVICES", "svc")
 
@@ -38,14 +39,60 @@ def test_save_list_load_delete_key(monkeypatch):
     assert api_keys.load_key("svc") is None
 
 
-def test_save_key_no_keyring(monkeypatch):
+class DummyFernet:
+    """Simple reversible "encryption" for tests."""
+
+    def __init__(self, key: bytes):
+        self.key = key
+
+    @staticmethod
+    def generate_key() -> bytes:
+        return b"0" * 32
+
+    def encrypt(self, data: bytes) -> bytes:
+        return data[::-1]
+
+    def decrypt(self, token: bytes) -> bytes:
+        return token[::-1]
+
+
+def test_file_backend_encrypted(tmp_path, monkeypatch):
+    monkeypatch.setattr(api_keys, "win32cred", None)
     monkeypatch.setattr(api_keys, "keyring", None)
-    monkeypatch.setattr(api_keys, "_migrate_file_to_keyring", lambda: None)
+    monkeypatch.setattr(api_keys, "Fernet", DummyFernet)
+    monkeypatch.setattr(api_keys, "CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(api_keys, "ENC_FILE", str(tmp_path / "keys.enc"))
+    monkeypatch.setattr(api_keys, "FERNET_KEY_FILE", str(tmp_path / "fernet.key"))
+
+    api_keys.save_key("svc", "secret")
+    assert api_keys.load_key("svc") == "secret"
+    assert api_keys.list_keys() == {"svc": "secret"}
+    assert api_keys.delete_key("svc") is True
+    assert api_keys.load_key("svc") is None
+
+    with open(api_keys.ENC_FILE, "rb") as f:
+        content = f.read()
+    assert b"secret" not in content
+
+
+def test_save_key_no_backend(tmp_path, monkeypatch):
+    monkeypatch.setattr(api_keys, "win32cred", None)
+    monkeypatch.setattr(api_keys, "keyring", None)
+    monkeypatch.setattr(api_keys, "Fernet", None)
+    monkeypatch.setattr(api_keys, "CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(api_keys, "ENC_FILE", str(tmp_path / "keys.enc"))
+    monkeypatch.setattr(api_keys, "FERNET_KEY_FILE", str(tmp_path / "fernet.key"))
+
     with pytest.raises(RuntimeError):
         api_keys.save_key("svc", "secret")
 
 
-def test_load_key_no_keyring(monkeypatch):
+def test_load_key_no_backend(tmp_path, monkeypatch):
+    monkeypatch.setattr(api_keys, "win32cred", None)
     monkeypatch.setattr(api_keys, "keyring", None)
-    monkeypatch.setattr(api_keys, "_migrate_file_to_keyring", lambda: None)
+    monkeypatch.setattr(api_keys, "Fernet", None)
+    monkeypatch.setattr(api_keys, "CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(api_keys, "ENC_FILE", str(tmp_path / "keys.enc"))
+    monkeypatch.setattr(api_keys, "FERNET_KEY_FILE", str(tmp_path / "fernet.key"))
+
     assert api_keys.load_key("svc") is None


### PR DESCRIPTION
## Summary
- add Windows Credential Manager/keyring API key storage with encrypted file fallback
- allow GUI installer to verify stored keys without revealing them
- cover key storage backends with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e51d263e4832692deb2c0187dddc1