### PR TITLE
Add environment setup orchestration and GUI integration

### DIFF
--- a/installer/env_setup.py
+++ b/installer/env_setup.py
@@ -1,0 +1,107 @@
+"""Environment orchestration for installer plugins and tools.
+
+This module builds on :mod:`installer.env` and :mod:`installer.plugins` to
+create isolated virtual or conda environments for each plugin (or tool
+category).  Prior to installation it performs a light-weight analysis of the
+requested package versions to warn about obvious conflicts.  When possible the
+conflicts can be automatically resolved by selecting the highest pinned version.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Tuple, Dict, List
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
+
+from . import env, plugins
+
+
+def _parse_requirements(requirements: Iterable[str]) -> Dict[str, List[Requirement]]:
+    """Group requirement strings by normalized package name."""
+
+    grouped: Dict[str, List[Requirement]] = {}
+    for req_str in requirements:
+        req = Requirement(req_str)
+        name = req.name.lower()
+        grouped.setdefault(name, []).append(req)
+    return grouped
+
+
+def resolve_conflicts(requirements: Iterable[str], auto_resolve: bool = True) -> Tuple[List[str], Dict[str, List[str]]]:
+    """Return a list of resolved requirement strings and detected conflicts.
+
+    Parameters
+    ----------
+    requirements:
+        Iterable of requirement strings.
+    auto_resolve:
+        When ``True`` conflicting pinned versions are resolved by choosing the
+        highest version.  When ``False`` the conflict remains and no package is
+        suggested for installation.
+    """
+
+    grouped = _parse_requirements(requirements)
+    resolved: List[str] = []
+    conflicts: Dict[str, List[str]] = {}
+
+    for name, reqs in grouped.items():
+        if len(reqs) == 1:
+            resolved.append(str(reqs[0]))
+            continue
+
+        pinned = {spec.version for r in reqs for spec in r.specifier if spec.operator in {"==", "==="}}
+        if len(pinned) > 1:
+            # conflicting explicit versions
+            conflicts[name] = [str(r) for r in reqs]
+            if auto_resolve:
+                chosen = max(pinned, key=Version)
+                resolved.append(f"{name}=={chosen}")
+            continue
+
+        # combine remaining specifiers (if any)
+        spec: SpecifierSet | None = None
+        for r in reqs:
+            spec = r.specifier if spec is None else spec & r.specifier
+        resolved.append(f"{name}{spec}")
+
+    return resolved, conflicts
+
+
+def setup_all(search_path: str | Path | None = None, auto_resolve: bool = True) -> Dict[str, Dict[str, object]]:
+    """Discover plugins and install their dependencies in isolated envs.
+
+    Parameters
+    ----------
+    search_path:
+        Optional directory to search for plugin modules.  This mirrors the
+        parameter of :func:`installer.plugins.discover_plugins` and mainly exists
+        to facilitate unit testing.
+    auto_resolve:
+        Passed to :func:`resolve_conflicts`.
+
+    Returns
+    -------
+    dict
+        Mapping of plugin name to information about the created environment. Each
+        entry contains the environment path, installed packages and any
+        conflicts encountered.
+    """
+
+    registry = plugins.discover_plugins(search_path)
+    report: Dict[str, Dict[str, object]] = {}
+
+    for name, deps in sorted(registry.dependencies.items()):
+        packages, conflicts = resolve_conflicts(deps, auto_resolve=auto_resolve)
+        env_path = env.create_env(name)
+        env.install_packages(env_path, packages)
+        report[name] = {
+            "env_path": env_path,
+            "packages": packages,
+            "conflicts": conflicts,
+        }
+    return report
+
+
+__all__ = ["resolve_conflicts", "setup_all"]

--- a/installer/gui_installer.py
+++ b/installer/gui_installer.py
@@ -39,6 +39,9 @@ class GUIInstaller:
         ttk.Button(button_frame, text="Check API Key", command=self.check_api_key).pack(
             side=tk.LEFT, padx=5
         )
+        ttk.Button(
+            button_frame, text="Install Dependencies", command=self.install_all
+        ).pack(side=tk.LEFT, padx=5)
 
         self.info = tk.Text(self.root, width=60, height=10, state="disabled")
         self.info.pack(padx=10, pady=5)
@@ -109,6 +112,28 @@ class GUIInstaller:
         finally:
             self.progress.stop()
             self.progress.config(mode="determinate", value=0)
+
+    # --- Dependency installation -----------------------------------------
+    def install_all(self) -> None:
+        """Install plugin/tool dependencies with one click."""
+
+        self.progress.config(mode="indeterminate")
+        self.progress.start()
+        threading.Thread(target=self._install_worker, daemon=True).start()
+
+    def _install_worker(self) -> None:
+        from . import env_setup
+
+        env_setup.setup_all()
+
+        def update() -> None:
+            self.progress.stop()
+            self.progress.config(mode="determinate", value=0)
+            messagebox.showinfo(
+                "Installer", "Plugin and tool dependencies installed"
+            )
+
+        self.root.after(0, update)
 
 
 def main() -> None:

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -1,0 +1,54 @@
+import types
+
+from installer import env_setup
+
+
+def test_resolve_conflicts_auto():
+    packages, conflicts = env_setup.resolve_conflicts(["pkg==1", "pkg==2"])
+    assert conflicts == {"pkg": ["pkg==1", "pkg==2"]}
+    assert packages == ["pkg==2"]
+
+
+def test_setup_all_creates_envs(tmp_path, monkeypatch):
+    # ensure no external entry points are discovered
+    dummy_eps = types.SimpleNamespace(select=lambda group: [])
+    monkeypatch.setattr(env_setup.plugins.registry, "entry_points", lambda: dummy_eps)
+
+    plugin_a = tmp_path / "a.py"
+    plugin_a.write_text(
+        """
+from installer.plugins.registry import PluginRegistry
+
+def register(registry: PluginRegistry):
+    registry.add_dependency('demo-one')
+"""
+    )
+
+    plugin_b = tmp_path / "b.py"
+    plugin_b.write_text(
+        """
+from installer.plugins.registry import PluginRegistry
+
+def register(registry: PluginRegistry):
+    registry.add_dependency('demo-two==1')
+"""
+    )
+
+    created = {}
+    installed = {}
+
+    def fake_create_env(name: str):
+        path = tmp_path / name
+        created[name] = path
+        return path
+
+    def fake_install_packages(path, packages):
+        installed[path.name] = list(packages)
+
+    monkeypatch.setattr(env_setup.env, "create_env", fake_create_env)
+    monkeypatch.setattr(env_setup.env, "install_packages", fake_install_packages)
+
+    env_setup.setup_all(search_path=tmp_path)
+
+    assert set(created) == {"a", "b"}
+    assert installed == {"a": ["demo-one"], "b": ["demo-two==1"]}


### PR DESCRIPTION
## Summary
- implement env_setup module for per-plugin virtual environments with conflict checking
- add GUI button to install dependencies using the new env setup logic
- add tests for conflict resolution and environment provisioning

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e53a9a9388326a4179523a5479144