### PR TITLE
Use relative import for Control Center backends

### DIFF
--- a/control_center/backends.py
+++ b/control_center/backends.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-__all__ = ["Backend", "LocalBackend", "RemoteBackend"]
+__all__ = ["Backend", "LocalBackend", "RemoteBackend", "load_backend"]
 
 
 class Backend(Protocol):
@@ -26,3 +26,20 @@ class RemoteBackend:
 
     def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
         return f"[remote] {prompt}"
+
+
+def load_backend(kind: str) -> Backend:
+    """Return a backend instance for *kind*.
+
+    Parameters
+    ----------
+    kind: str
+        Either ``"local"`` or ``"remote"``.
+    """
+
+    kind = kind.lower()
+    if kind == "local":
+        return LocalBackend()
+    if kind == "remote":
+        return RemoteBackend()
+    raise ValueError(f"unknown backend: {kind}")

--- a/control_center/chat_ui.py
+++ b/control_center/chat_ui.py
@@ -16,7 +16,7 @@ except Exception:  # pragma: no cover - headless environment
     tk = None
     ttk = None
 
-from backends import Backend, load_backend
+from .backends import Backend, load_backend
 from . import get_plugins
 
 __all__ = ["ChatUI", "main"]


### PR DESCRIPTION
## Summary
- Use package-relative import for Control Center backends
- Add load_backend helper to the Control Center backends module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688facace2b08326abd7998a0ea1394f