### PR TITLE
Harden shell action with whitelist and spawn

### DIFF
--- a/apps/actions-api/src/actions.ts
+++ b/apps/actions-api/src/actions.ts
@@ -1,9 +1,8 @@
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { spawn } from 'child_process';
 import fs from 'fs/promises';
 import os from 'os';
 
-const execAsync = promisify(exec);
+const ALLOWED_COMMANDS = new Set(['echo', 'ls', 'cat', 'pwd']);
 
 export interface ActionRequest {
   action: string;
@@ -15,8 +14,37 @@ export async function executeAction(req: ActionRequest): Promise<any> {
     case 'shell': {
       const cmd = req.params?.command;
       if (!cmd) throw new Error('Missing command');
-      const { stdout } = await execAsync(cmd, { timeout: req.params?.timeout_ms ?? 10000 });
-      return { stdout };
+      if (!/^[-\w\s/.]+$/.test(cmd)) {
+        throw new Error('Command contains disallowed characters');
+      }
+      const [program, ...args] = cmd.trim().split(/\s+/);
+      if (!ALLOWED_COMMANDS.has(program)) {
+        throw new Error(`Command not allowed: ${program}`);
+      }
+      return await new Promise((resolve, reject) => {
+        const child = spawn(program, args);
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (d) => (stdout += d));
+        child.stderr.on('data', (d) => (stderr += d));
+        const timeoutMs = req.params?.timeout_ms ?? 10000;
+        const timer = setTimeout(() => {
+          child.kill();
+          reject(new Error('Command timed out'));
+        }, timeoutMs);
+        child.on('error', (err) => {
+          clearTimeout(timer);
+          reject(err);
+        });
+        child.on('close', (code) => {
+          clearTimeout(timer);
+          if (code !== 0) {
+            reject(new Error(stderr || `Exited with code ${code}`));
+          } else {
+            resolve({ stdout });
+          }
+        });
+      });
     }
     case 'read_file': {
       const path = req.params?.path;

--- a/apps/actions-api/test/actions.test.ts
+++ b/apps/actions-api/test/actions.test.ts
@@ -9,6 +9,18 @@ test('shell executes command', async () => {
   assert.strictEqual(result.stdout.trim(), 'hello');
 });
 
+test('shell rejects command with disallowed characters', async () => {
+  await assert.rejects(
+    executeAction({ action: 'shell', params: { command: 'echo hello; ls' } })
+  );
+});
+
+test('shell rejects command not in whitelist', async () => {
+  await assert.rejects(
+    executeAction({ action: 'shell', params: { command: 'rm -rf /' } })
+  );
+});
+
 test('write_file and read_file', async () => {
   const tmp = path.join(process.cwd(), 'tmp.txt');
   await executeAction({ action: 'write_file', params: { path: tmp, content: 'hi' } });


### PR DESCRIPTION
## Summary
- Sanitize shell commands and restrict to a safe whitelist before execution
- Replace `exec` with `spawn` to avoid shell interpretation and enforce timeouts
- Add tests to verify unsafe commands are rejected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fae38d9f883269d1f84e477efbe14