### PR TITLE
Handle validation errors and unexpected exceptions

### DIFF
--- a/apps/actions-api/package.json
+++ b/apps/actions-api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "node -r ts-node/register test/actions.test.ts"
+    "test": "node --test -r ts-node/register test/*.test.ts"
   },
   "dependencies": {
     "express": "^5.1.0"

--- a/apps/actions-api/src/actions.ts
+++ b/apps/actions-api/src/actions.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process';
 import fs from 'fs/promises';
 import os from 'os';
+import { ValidationError } from './errors';
 
 const ALLOWED_COMMANDS = new Set(['echo', 'ls', 'cat', 'pwd']);
 
@@ -13,13 +14,13 @@ export async function executeAction(req: ActionRequest): Promise<any> {
   switch (req.action) {
     case 'shell': {
       const cmd = req.params?.command;
-      if (!cmd) throw new Error('Missing command');
+      if (!cmd) throw new ValidationError('Missing command');
       if (!/^[-\w\s/.]+$/.test(cmd)) {
-        throw new Error('Command contains disallowed characters');
+        throw new ValidationError('Command contains disallowed characters');
       }
       const [program, ...args] = cmd.trim().split(/\s+/);
       if (!ALLOWED_COMMANDS.has(program)) {
-        throw new Error(`Command not allowed: ${program}`);
+        throw new ValidationError(`Command not allowed: ${program}`);
       }
       return await new Promise((resolve, reject) => {
         const child = spawn(program, args);
@@ -48,12 +49,12 @@ export async function executeAction(req: ActionRequest): Promise<any> {
     }
     case 'read_file': {
       const path = req.params?.path;
-      if (!path) throw new Error('Missing path');
+      if (!path) throw new ValidationError('Missing path');
       return { content: await fs.readFile(path, 'utf8') };
     }
     case 'write_file': {
       const path = req.params?.path;
-      if (!path) throw new Error('Missing path');
+      if (!path) throw new ValidationError('Missing path');
       const content = req.params?.content ?? '';
       await fs.writeFile(path, content, 'utf8');
       return { ok: true };
@@ -66,6 +67,6 @@ export async function executeAction(req: ActionRequest): Promise<any> {
       };
     }
     default:
-      throw new Error(`Unknown action: ${req.action}`);
+      throw new ValidationError(`Unknown action: ${req.action}`);
   }
 }

--- a/apps/actions-api/src/errors.ts
+++ b/apps/actions-api/src/errors.ts
@@ -1,0 +1,6 @@
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}

--- a/apps/actions-api/src/index.ts
+++ b/apps/actions-api/src/index.ts
@@ -1,8 +1,9 @@
 import express from 'express';
 import { executeAction } from './actions';
 import { normalize } from './normalize';
+import { ValidationError } from './errors';
 
-const app = express();
+export const app = express();
 app.use(express.json());
 
 app.post('/api/actions/execute', async (req, res) => {
@@ -11,12 +12,26 @@ app.post('/api/actions/execute', async (req, res) => {
     const result = await executeAction(norm);
     res.json({ ok: true, result });
   } catch (err: any) {
-    console.error(JSON.stringify({ level: 'error', message: err.message }));
-    res.status(400).json({ ok: false, error: { message: err.message } });
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack
+        })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
   }
 });
 
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(JSON.stringify({ level: 'info', message: 'actions api listening', port }));
-});
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(
+      JSON.stringify({ level: 'info', message: 'actions api listening', port })
+    );
+  });
+}

--- a/apps/actions-api/src/normalize.ts
+++ b/apps/actions-api/src/normalize.ts
@@ -1,3 +1,5 @@
+import { ValidationError } from './errors';
+
 export interface NormalizedRequest {
   action: string;
   params?: Record<string, any>;
@@ -7,7 +9,7 @@ const allowed = new Set(['shell', 'read_file', 'write_file', 'get_system_info'])
 
 export function normalize(input: any): NormalizedRequest {
   if (!input || typeof input.action !== 'string' || !allowed.has(input.action)) {
-    throw new Error('Invalid action');
+    throw new ValidationError('Invalid action');
   }
   const params = input.params && typeof input.params === 'object' ? input.params : {};
   return { action: input.action, params };

--- a/apps/actions-api/test/api.test.ts
+++ b/apps/actions-api/test/api.test.ts
@@ -1,0 +1,39 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { app } from '../src/index';
+
+async function startServer() {
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  const address = server.address();
+  if (typeof address === 'string' || !address) {
+    throw new Error('Failed to get server address');
+  }
+  return { server, port: address.port };
+}
+
+test('returns 400 for validation errors', async () => {
+  const { server, port } = await startServer();
+  const res = await fetch(`http://localhost:${port}/api/actions/execute`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ action: 'invalid' })
+  });
+  assert.strictEqual(res.status, 400);
+  const body = await res.json();
+  assert.strictEqual(body.ok, false);
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test('returns 500 for unexpected errors', async () => {
+  const { server, port } = await startServer();
+  const res = await fetch(`http://localhost:${port}/api/actions/execute`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ action: 'read_file', params: { path: '/no/such/file' } })
+  });
+  assert.strictEqual(res.status, 500);
+  const body = await res.json();
+  assert.strictEqual(body.ok, false);
+  await new Promise((resolve) => server.close(resolve));
+});


### PR DESCRIPTION
## Summary
- Distinguish validation errors from unexpected exceptions in `/api/actions/execute`
- Introduce `ValidationError` and update action handlers accordingly
- Add tests ensuring 400 and 500 status codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fb0c50d24832698ad1eab9001f384