### PR TITLE
Add configurable agenthub URLs and error handling

### DIFF
--- a/apps/agenthub/main.py
+++ b/apps/agenthub/main.py
@@ -1,10 +1,11 @@
+import os
 from fastapi import FastAPI
 import httpx
 
 app = FastAPI()
 
-ACTIONS_URL = "http://localhost:3000/api/actions/execute"
-PROXY_URL = "http://localhost:11434/v1/chat/completions"
+ACTIONS_URL = os.getenv("ACTIONS_URL", "http://localhost:3000/api/actions/execute")
+PROXY_URL = os.getenv("PROXY_URL", "http://localhost:11434/v1/chat/completions")
 
 @app.get("/health")
 async def health():
@@ -13,6 +14,22 @@ async def health():
 @app.post("/pipeline/sample")
 async def pipeline_sample():
     async with httpx.AsyncClient() as client:
-        action = await client.post(ACTIONS_URL, json={"action": "get_system_info"})
-        proxy = await client.post(PROXY_URL, json={"model": "dummy", "messages": []})
-    return {"action": action.json(), "proxy": proxy.json()}
+        try:
+            action = await client.post(
+                ACTIONS_URL, json={"action": "get_system_info"}
+            )
+            action.raise_for_status()
+            action_data = action.json()
+        except httpx.HTTPError as exc:
+            return {"error": f"Action service unreachable: {exc}"}
+
+        try:
+            proxy = await client.post(
+                PROXY_URL, json={"model": "dummy", "messages": []}
+            )
+            proxy.raise_for_status()
+            proxy_data = proxy.json()
+        except httpx.HTTPError as exc:
+            return {"action": action_data, "error": f"Proxy service unreachable: {exc}"}
+
+    return {"action": action_data, "proxy": proxy_data}

--- a/tests/test_agenthub.py
+++ b/tests/test_agenthub.py
@@ -1,0 +1,68 @@
+import importlib
+
+import httpx
+from fastapi.testclient import TestClient
+
+
+def get_app(monkeypatch, actions_url=None, proxy_url=None):
+    if actions_url is not None:
+        monkeypatch.setenv("ACTIONS_URL", actions_url)
+    else:
+        monkeypatch.delenv("ACTIONS_URL", raising=False)
+    if proxy_url is not None:
+        monkeypatch.setenv("PROXY_URL", proxy_url)
+    else:
+        monkeypatch.delenv("PROXY_URL", raising=False)
+    import apps.agenthub.main as main
+    importlib.reload(main)
+    return main
+
+
+def test_custom_urls(monkeypatch):
+    main = get_app(
+        monkeypatch,
+        actions_url="http://example.com/actions",
+        proxy_url="http://example.com/proxy",
+    )
+    urls = []
+
+    async def mock_post(self, url, *args, **kwargs):
+        urls.append(url)
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    client = TestClient(main.app)
+    resp = client.post("/pipeline/sample")
+    assert resp.status_code == 200
+    assert urls == ["http://example.com/actions", "http://example.com/proxy"]
+
+
+def test_action_service_unreachable(monkeypatch):
+    main = get_app(monkeypatch)
+
+    async def mock_post(self, url, *args, **kwargs):
+        raise httpx.RequestError("boom", request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    client = TestClient(main.app)
+    resp = client.post("/pipeline/sample")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"].startswith("Action service unreachable")
+
+
+def test_proxy_service_unreachable(monkeypatch):
+    main = get_app(monkeypatch)
+
+    async def mock_post(self, url, *args, **kwargs):
+        if url == main.ACTIONS_URL:
+            return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+        raise httpx.RequestError("boom", request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    client = TestClient(main.app)
+    resp = client.post("/pipeline/sample")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["action"] == {"ok": True}
+    assert data["error"].startswith("Proxy service unreachable")


### PR DESCRIPTION
## Summary
- allow overriding ACTIONS_URL and PROXY_URL via environment variables
- add robust error handling around external HTTP requests
- cover custom URLs and failure scenarios with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fb2a33e5c832688bcadd08f4dac44