### PR TITLE
Support Windows shell commands

### DIFF
--- a/apps/actions-api/src/actions.ts
+++ b/apps/actions-api/src/actions.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises';
 import os from 'os';
 import { ValidationError } from './errors';
 
-const ALLOWED_COMMANDS = new Set(['echo', 'ls', 'cat', 'pwd']);
+const ALLOWED_COMMANDS = new Set(['echo', 'ls', 'cat', 'pwd', 'dir', 'type']);
 
 export interface ActionRequest {
   action: string;
@@ -22,8 +22,9 @@ export async function executeAction(req: ActionRequest): Promise<any> {
       if (!ALLOWED_COMMANDS.has(program)) {
         throw new ValidationError(`Command not allowed: ${program}`);
       }
+      const isWindows = process.platform === 'win32';
       return await new Promise((resolve, reject) => {
-        const child = spawn(program, args);
+        const child = spawn(program, args, isWindows ? { shell: true } : undefined);
         let stdout = '';
         let stderr = '';
         child.stdout.on('data', (d) => (stdout += d));

--- a/apps/actions-api/test/actions.test.ts
+++ b/apps/actions-api/test/actions.test.ts
@@ -9,6 +9,18 @@ test('shell executes command', async () => {
   assert.strictEqual(result.stdout.trim(), 'hello');
 });
 
+test('shell runs platform-specific list command', async () => {
+  const cmd = process.platform === 'win32' ? 'dir' : 'ls';
+  const result = await executeAction({ action: 'shell', params: { command: cmd } });
+  assert.ok(result.stdout.toLowerCase().includes('package.json'));
+});
+
+test('shell prints file contents', async () => {
+  const cmd = process.platform === 'win32' ? 'type package.json' : 'cat package.json';
+  const result = await executeAction({ action: 'shell', params: { command: cmd } });
+  assert.ok(result.stdout.includes('"name"'));
+});
+
 test('shell rejects command with disallowed characters', async () => {
   await assert.rejects(
     executeAction({ action: 'shell', params: { command: 'echo hello; ls' } })


### PR DESCRIPTION
## Summary
- allow shell action to run on Windows by spawning built-ins via shell
- broaden allowed command list with Windows equivalents
- add cross-platform tests for shell command execution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fb9d5c2208326bf0cbf70714d4940