### PR TITLE
Harden terminal engine command execution

### DIFF
--- a/terminal/engine.py
+++ b/terminal/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 import subprocess
 from typing import List, Tuple
 
@@ -13,8 +14,15 @@ class TerminalEngine:
     def run(self, command: str) -> str:
         """Run *command* in a subprocess and capture stdout."""
 
+        if any(char in command for char in ["|", ">", "<"]):
+            raise ValueError("Pipes and redirection are not allowed")
+
         completed = subprocess.run(
-            command, shell=True, capture_output=True, text=True, check=False
+            shlex.split(command),
+            shell=False,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         output = completed.stdout.strip()
         self.history.append((command, output))

--- a/tests/test_terminal_engine.py
+++ b/tests/test_terminal_engine.py
@@ -1,4 +1,5 @@
 from terminal.engine import TerminalEngine
+import pytest
 
 
 def test_run_command():
@@ -6,3 +7,21 @@ def test_run_command():
     out = engine.run("echo hello")
     assert out == "hello"
     assert engine.history[0] == ("echo hello", "hello")
+
+
+def test_run_multi_word_command():
+    engine = TerminalEngine()
+    out = engine.run("echo hello world")
+    assert out == "hello world"
+
+
+def test_rejects_piped_command():
+    engine = TerminalEngine()
+    with pytest.raises(ValueError):
+        engine.run("echo hi | grep h")
+
+
+def test_rejects_redirection_command():
+    engine = TerminalEngine()
+    with pytest.raises(ValueError):
+        engine.run("echo hi > /tmp/out")


### PR DESCRIPTION
## Summary
- avoid shell invocation by splitting commands and disabling pipes/redirection
- test terminal engine against injection attempts and multi-word commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fbb2ca64c8326a2f79afb0e2a58a1