### PR TITLE
feat(installer): validate plugin commands

### DIFF
--- a/installer/plugins/manager.py
+++ b/installer/plugins/manager.py
@@ -7,6 +7,7 @@ will invoke the associated installation commands.
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -89,12 +90,20 @@ class PluginManager:
         ttk.Button(root, text="Install Selected", command=_install).pack(pady=5)
         root.mainloop()
 
+    ALLOWED_COMMANDS = {"pip", "npm", "brew"}
+
     # --- Installation ----------------------------------------------------
     def install(self, plugin: Plugin, messagebox=None) -> None:
         """Run the installation command for a plugin."""
 
         try:
-            subprocess.run(plugin.command, shell=True, check=True)
+            args = shlex.split(plugin.command)
+            if not args:
+                raise ValueError("Empty command")
+            executable = Path(args[0])
+            if not executable.is_absolute() and executable.name not in self.ALLOWED_COMMANDS:
+                raise ValueError("Command not allowed")
+            subprocess.run(args, shell=False, check=True)
         except Exception as exc:  # pragma: no cover - subprocess path
             if messagebox is not None:
                 messagebox.showerror(

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,4 +1,9 @@
-from installer.plugins.manager import PluginManager, load_catalog
+import shutil
+import subprocess
+
+import pytest
+
+from installer.plugins.manager import Plugin, PluginManager, load_catalog
 
 
 def test_catalog_loads_default_manifest():
@@ -12,3 +17,31 @@ def test_catalog_loads_default_manifest():
 def test_plugin_manager_initializes():
     manager = PluginManager()
     assert manager.plugins  # catalog should not be empty
+
+
+def test_install_runs_absolute_command(monkeypatch):
+    echo_path = shutil.which("echo")
+    assert echo_path
+    plugin = Plugin(name="Echo", description="", command=f"{echo_path} hello")
+    manager = PluginManager()
+
+    recorded: dict[str, object] = {}
+
+    def fake_run(args, shell, check):
+        recorded["args"] = args
+        recorded["shell"] = shell
+        recorded["check"] = check
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    manager.install(plugin)
+
+    assert recorded["args"] == [echo_path, "hello"]
+    assert recorded["shell"] is False
+    assert recorded["check"] is True
+
+
+def test_install_rejects_unsafe_command():
+    plugin = Plugin(name="Unsafe", description="", command="echo hello")
+    manager = PluginManager()
+    with pytest.raises(ValueError):
+        manager.install(plugin)


### PR DESCRIPTION
## Summary
- secure plugin installation by validating allowed commands and avoiding shell
- add tests for running allowed commands and rejecting unsafe ones

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fbe5c561c832699802b414678855b