### PR TITLE
feat: allow headless import of control center GUI

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -6,9 +6,14 @@ to switch between local models and remote APIs.
 
 from __future__ import annotations
 
-import tkinter as tk
-from tkinter import ttk
 from typing import Dict, Optional
+
+try:  # pragma: no cover - import may fail on headless systems
+    import tkinter as tk  # type: ignore
+    from tkinter import ttk  # type: ignore
+except Exception:  # pragma: no cover - environment specific
+    tk = None  # type: ignore[assignment]
+    ttk = None  # type: ignore[assignment]
 
 from .backends import Backend, LocalBackend, RemoteBackend
 from . import get_plugins
@@ -21,9 +26,11 @@ class ChatGUI:
 
     def __init__(
         self,
-        root: Optional[tk.Tk] = None,
+        root: Optional["tk.Tk"] = None,
         backends: Optional[Dict[str, Backend]] = None,
     ) -> None:
+        if tk is None or ttk is None:
+            raise RuntimeError("tkinter is not available")
         try:
             self.root = root or tk.Tk()
         except tk.TclError as exc:  # pragma: no cover - environment specific

--- a/tests/test_control_center_gui.py
+++ b/tests/test_control_center_gui.py
@@ -1,0 +1,40 @@
+import builtins
+import importlib
+import sys
+
+import pytest
+
+
+def test_headless_import(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("tkinter"):
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("tkinter", None)
+    sys.modules.pop("tkinter.ttk", None)
+    sys.modules.pop("control_center.gui", None)
+
+    gui = importlib.import_module("control_center.gui")
+    assert gui.tk is None
+    assert gui.ttk is None
+    with pytest.raises(RuntimeError):
+        gui.ChatGUI()
+
+
+def test_gui_launches_with_tkinter():
+    gui = importlib.import_module("control_center.gui")
+    if gui.tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = gui.tk.Tk()
+    except gui.tk.TclError:
+        pytest.skip("tkinter cannot open display")
+    root.withdraw()
+    try:
+        gui.ChatGUI(root=root)
+    finally:
+        root.destroy()


### PR DESCRIPTION
## Summary
- guard `tkinter` imports so module can load without a display
- prevent GUI construction when `tkinter` or a display is missing
- test headless import and GUI initialization when `tkinter` is available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc00e8a64832691962beb5ac06c31