### PR TITLE
feat: add mobile pairing and companion app scaffold

### DIFF
--- a/apps/actions-api/src/index.ts
+++ b/apps/actions-api/src/index.ts
@@ -2,9 +2,51 @@ import express from 'express';
 import { executeAction } from './actions';
 import { normalize } from './normalize';
 import { ValidationError } from './errors';
+import { createPairingToken, handleRemoteCommand } from './mobile';
 
 export const app = express();
 app.use(express.json());
+
+app.post('/api/mobile/pair', (req, res) => {
+  try {
+    const token = createPairingToken(req.body.deviceId);
+    res.json({ ok: true, token });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack
+        })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/mobile/command', async (req, res) => {
+  try {
+    const { token, ...body } = req.body;
+    const result = await handleRemoteCommand(token, body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack
+        })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
 
 app.post('/api/actions/execute', async (req, res) => {
   try {

--- a/apps/actions-api/src/mobile.ts
+++ b/apps/actions-api/src/mobile.ts
@@ -1,0 +1,26 @@
+import crypto from 'node:crypto';
+import { executeAction } from './actions';
+import { normalize } from './normalize';
+import { ValidationError } from './errors';
+
+const tokens = new Set<string>();
+
+export function createPairingToken(deviceId: string): string {
+  if (!deviceId) {
+    throw new ValidationError('deviceId is required');
+  }
+  const token = crypto.randomBytes(16).toString('hex');
+  tokens.add(token);
+  return token;
+}
+
+export async function handleRemoteCommand(
+  token: string,
+  body: unknown
+): Promise<unknown> {
+  if (!tokens.has(token)) {
+    throw new ValidationError('Invalid token');
+  }
+  const norm = normalize(body as any);
+  return await executeAction(norm);
+}

--- a/apps/actions-api/test/mobile.test.ts
+++ b/apps/actions-api/test/mobile.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { app } from '../src/index';
+
+async function startServer() {
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  const address = server.address();
+  if (typeof address === 'string' || !address) {
+    throw new Error('Failed to get server address');
+  }
+  return { server, port: address.port };
+}
+
+test('pairing returns token', async () => {
+  const { server, port } = await startServer();
+  const res = await fetch(`http://localhost:${port}/api/mobile/pair`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ deviceId: 'device1' })
+  });
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.strictEqual(body.ok, true);
+  assert.ok(body.token);
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test('remote command executes with token', async () => {
+  const { server, port } = await startServer();
+  const pairRes = await fetch(`http://localhost:${port}/api/mobile/pair`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ deviceId: 'device2' })
+  });
+  const token = (await pairRes.json()).token;
+  const cmdRes = await fetch(`http://localhost:${port}/api/mobile/command`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token, action: 'get_system_info' })
+  });
+  assert.strictEqual(cmdRes.status, 200);
+  const body = await cmdRes.json();
+  assert.strictEqual(body.ok, true);
+  assert.ok(body.result.platform);
+  await new Promise((resolve) => server.close(resolve));
+});
+
+test('remote command rejects invalid token', async () => {
+  const { server, port } = await startServer();
+  const cmdRes = await fetch(`http://localhost:${port}/api/mobile/command`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ token: 'bad', action: 'get_system_info' })
+  });
+  assert.strictEqual(cmdRes.status, 400);
+  const body = await cmdRes.json();
+  assert.strictEqual(body.ok, false);
+  await new Promise((resolve) => server.close(resolve));
+});

--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -19,6 +19,12 @@ from .backends import Backend, LocalBackend, RemoteBackend
 from . import get_plugins
 from mesh import MeshNode
 from iot import ADAPTERS, discover_devices, pair_device
+from secrets import token_urlsafe
+
+try:  # pragma: no cover - optional dependency
+    import qrcode  # type: ignore
+except Exception:  # pragma: no cover
+    qrcode = None  # type: ignore[assignment]
 
 __all__ = ["ChatGUI", "main"]
 
@@ -88,6 +94,9 @@ class ChatGUI:
         ttk.Button(input_frame, text="IoT", command=self._open_iot_window).pack(
             side="left", padx=5
         )
+        ttk.Button(
+            input_frame, text="Pair Mobile", command=self._open_mobile_pair_window
+        ).pack(side="left", padx=5)
 
     # ----------------------------------------------------------------- Chat
     def _open_mesh_config(self) -> None:
@@ -162,6 +171,23 @@ class ChatGUI:
         ttk.Button(win, text="Pair", command=do_pair).grid(
             row=2, column=1, padx=5, pady=5, sticky="ew"
         )
+
+    # ----------------------------------------------------------- Mobile Pairing
+    def _open_mobile_pair_window(self) -> None:
+        """Display a pairing token and optional QR code."""
+
+        win = tk.Toplevel(self.root)
+        win.title("Mobile Pairing")
+        token = token_urlsafe(8)
+        if qrcode:
+            qr = qrcode.QRCode(border=1)
+            qr.add_data(token)
+            qr.make(fit=True)
+            ascii_qr = "\n".join(
+                "".join("██" if cell else "  " for cell in row) for row in qr.get_matrix()
+            )
+            tk.Label(win, font=("Courier", 1), text=ascii_qr).pack(padx=5, pady=5)
+        ttk.Label(win, text=f"Token: {token}").pack(padx=5, pady=5)
 
     # ----------------------------------------------------------------- Chat
     def send_message(self, event: object | None = None) -> None:

--- a/docs/mobile_companion.md
+++ b/docs/mobile_companion.md
@@ -1,0 +1,27 @@
+# Mobile Companion Setup
+
+This guide outlines how to try the placeholder mobile companion app and pair it with the desktop Control Center.
+
+## Prerequisites
+- Node.js and npm
+- An emulator or device capable of running React Native apps
+
+## Running the App
+1. Navigate to the `mobile/` directory and install dependencies:
+   ```sh
+   npm install
+   npm start
+   ```
+2. Use your emulator or the Expo app to open the development server.
+3. Sign in with any credentials. Authentication is not yet wired up.
+
+## Pairing with the Desktop
+1. In the desktop Control Center, choose **Pair Mobile** to display a secure token or QR code.
+2. Enter the token into the mobile app's pairing screen.
+3. Once paired, the token can be used to send remote commands through the Actions API.
+
+## API Overview
+- `POST /api/mobile/pair` → obtain a pairing token for a device.
+- `POST /api/mobile/command` → execute an action on the paired desktop.
+
+These endpoints are provided by the `apps/actions-api` service and are still under active development.

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+android/
+ios/

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button } from 'react-native';
+
+export default function App() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [deviceId, setDeviceId] = useState('');
+  const [token, setToken] = useState(null);
+
+  const login = () => {
+    // Placeholder auth
+    setLoggedIn(true);
+  };
+
+  const pair = async () => {
+    // Placeholder API call
+    setToken('demo-token');
+  };
+
+  if (!loggedIn) {
+    return (
+      <View style={{ padding: 20 }}>
+        <Text>Login</Text>
+        <TextInput placeholder="Username" value={username} onChangeText={setUsername} />
+        <TextInput
+          placeholder="Password"
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+        />
+        <Button title="Login" onPress={login} />
+      </View>
+    );
+  }
+
+  if (!token) {
+    return (
+      <View style={{ padding: 20 }}>
+        <Text>Pair with Desktop</Text>
+        <TextInput placeholder="Device ID" value={deviceId} onChangeText={setDeviceId} />
+        <Button title="Pair" onPress={pair} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ padding: 20 }}>
+      <Text>Paired as {deviceId}</Text>
+      <Text>Token: {token}</Text>
+    </View>
+  );
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "windows-ai-mobile",
+  "version": "0.0.1",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "0.73.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile pairing and remote command endpoints in actions-api
- scaffold React Native companion app with login and pairing flows
- expose desktop pairing UI with QR/token display

## Testing
- `npm --prefix apps/actions-api run build`
- `npm --prefix apps/actions-api test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fda97a49c8326812d4bcf76b9e285