### PR TITLE
Add cloud sync utilities and hybrid inference mode

### DIFF
--- a/cloud_sync/__init__.py
+++ b/cloud_sync/__init__.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+"""Utilities for syncing encrypted profile and model data to cloud providers."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Protocol
+import hashlib
+from itertools import cycle
+
+
+class Provider(Protocol):
+    """Abstract storage provider used by :class:`CloudSync`."""
+
+    def upload(self, name: str, data: bytes) -> None:
+        """Upload ``data`` under ``name``."""
+
+    def download(self, name: str) -> bytes | None:
+        """Retrieve data previously uploaded under ``name``."""
+
+
+class InMemoryProvider:
+    """Simple in-memory provider used for testing."""
+
+    def __init__(self) -> None:
+        self.storage: Dict[str, bytes] = {}
+
+    def upload(self, name: str, data: bytes) -> None:  # pragma: no cover - tiny
+        self.storage[name] = data
+
+    def download(self, name: str) -> bytes | None:  # pragma: no cover - tiny
+        return self.storage.get(name)
+
+
+def _xor(data: bytes, key: bytes) -> bytes:
+    return bytes(a ^ b for a, b in zip(data, cycle(key)))
+
+
+def encrypt(data: bytes, password: str) -> bytes:
+    """Encrypt ``data`` with ``password`` using a simple XOR scheme."""
+
+    key = hashlib.sha256(password.encode()).digest()
+    return _xor(data, key)
+
+
+def decrypt(data: bytes, password: str) -> bytes:
+    """Decrypt ``data`` with ``password``."""
+
+    return encrypt(data, password)
+
+
+@dataclass
+class CloudSync:
+    """High level interface for backing up files to a provider."""
+
+    provider: Provider
+    password: str
+    conflict_resolution: str = "ask"
+
+    def backup_file(self, path: str | Path, name: str) -> None:
+        data = Path(path).read_bytes()
+        enc = encrypt(data, self.password)
+        self.provider.upload(name, enc)
+
+    def restore_file(self, path: str | Path, name: str) -> bool:
+        data = self.provider.download(name)
+        if data is None:
+            return False
+        dec = decrypt(data, self.password)
+        Path(path).write_bytes(dec)
+        return True
+
+    def sync_file(self, path: str | Path, name: str) -> str:
+        """Synchronise ``path`` with remote ``name``.
+
+        Returns a string describing the action taken:
+        ``"uploaded"``, ``"downloaded"``, ``"noop`` or raises ``RuntimeError``
+        if a conflict occurs and ``conflict_resolution`` is ``"ask"``.
+        """
+
+        local_path = Path(path)
+        local_bytes = local_path.read_bytes() if local_path.exists() else None
+        remote_enc = self.provider.download(name)
+        remote_bytes = (
+            decrypt(remote_enc, self.password) if remote_enc is not None else None
+        )
+
+        if remote_bytes is None and local_bytes is not None:
+            self.provider.upload(name, encrypt(local_bytes, self.password))
+            return "uploaded"
+
+        if remote_bytes is not None and local_bytes is None:
+            local_path.write_bytes(remote_bytes)
+            return "downloaded"
+
+        if remote_bytes is None and local_bytes is None:
+            return "noop"
+
+        assert remote_bytes is not None and local_bytes is not None
+        if remote_bytes == local_bytes:
+            return "noop"
+
+        if self.conflict_resolution == "local":
+            self.provider.upload(name, encrypt(local_bytes, self.password))
+            return "uploaded"
+        if self.conflict_resolution == "remote":
+            local_path.write_bytes(remote_bytes)
+            return "downloaded"
+        raise RuntimeError("sync conflict")
+
+
+__all__ = [
+    "Provider",
+    "InMemoryProvider",
+    "CloudSync",
+    "encrypt",
+    "decrypt",
+]

--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -51,6 +51,9 @@ class ChatGUI:
         }
         self.backend_var = tk.StringVar(value=next(iter(self.backends)))
         self.mesh_node: MeshNode | None = None
+        # Sync settings
+        self.sync_frequency = 60  # minutes
+        self.conflict_resolution = "ask"
 
         self._build_widgets()
 
@@ -96,6 +99,9 @@ class ChatGUI:
         )
         ttk.Button(
             input_frame, text="Pair Mobile", command=self._open_mobile_pair_window
+        ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Sync Settings", command=self._open_sync_settings
         ).pack(side="left", padx=5)
 
     # ----------------------------------------------------------------- Chat
@@ -202,6 +208,38 @@ class ChatGUI:
         response = backend.generate(prompt)
         self.chat.insert("end", f"Bot: {response}\n")
         self.chat.see("end")
+
+    # ---------------------------------------------------------- Sync settings
+    def _open_sync_settings(self) -> None:
+        win = tk.Toplevel(self.root)
+        win.title("Sync Settings")
+        freq_var = tk.IntVar(value=self.sync_frequency)
+        strat_var = tk.StringVar(value=self.conflict_resolution)
+
+        ttk.Label(win, text="Frequency (min):").grid(
+            row=0, column=0, padx=5, pady=5, sticky="w"
+        )
+        ttk.Entry(win, textvariable=freq_var, width=10).grid(
+            row=0, column=1, padx=5, pady=5, sticky="ew"
+        )
+        ttk.Label(win, text="On conflict:").grid(
+            row=1, column=0, padx=5, pady=5, sticky="w"
+        )
+        ttk.Combobox(
+            win,
+            textvariable=strat_var,
+            values=["ask", "local", "remote"],
+            state="readonly",
+        ).grid(row=1, column=1, padx=5, pady=5, sticky="ew")
+
+        def save() -> None:
+            self.sync_frequency = freq_var.get()
+            self.conflict_resolution = strat_var.get()
+            win.destroy()
+
+        ttk.Button(win, text="Save", command=save).grid(
+            row=2, column=0, columnspan=2, pady=5
+        )
 
     def run(self) -> None:  # pragma: no cover - GUI loop
         """Start the Tk event loop."""

--- a/docs/cloud_sync.md
+++ b/docs/cloud_sync.md
@@ -1,0 +1,30 @@
+# Cloud Sync
+
+The `cloud_sync` module provides a lightweight interface for backing up user
+profiles and downloaded models to cloud providers.  Data is encrypted with a
+password before leaving the local machine.  The default implementation ships
+with an in-memory provider used for testing, while real deployments can supply
+implementations for services like S3, Dropbox or Google Drive.
+
+## Basic Usage
+
+```python
+from cloud_sync import CloudSync, InMemoryProvider
+
+provider = InMemoryProvider()
+sync = CloudSync(provider, password="secret", conflict_resolution="local")
+
+sync.backup_file("profile.json", "profile")
+```
+
+## Conflict Resolution
+
+`CloudSync.sync_file` compares local and remote copies.  When both differ the
+`conflict_resolution` policy determines the outcome:
+
+- `"local"` – upload the local file over the remote copy.
+- `"remote"` – overwrite the local file with the remote version.
+- `"ask"` – raise a `RuntimeError` signalling a conflict.
+
+This behaviour is exposed in the Control Center GUI where users can also
+configure the sync frequency.

--- a/installer/models.py
+++ b/installer/models.py
@@ -83,6 +83,30 @@ def compatible_models(info: Dict[str, float | str | None]) -> List[ModelInfo]:
     return results
 
 
+def select_inference_mode(task: str, policy: str = "hybrid") -> str:
+    """Return the desired inference mode for ``task``.
+
+    Parameters
+    ----------
+    task:
+        Identifier of the task or model.  For ``"hybrid"`` policy this is used
+        to determine whether a local model exists.
+    policy:
+        ``"local"`` forces local execution, ``"cloud"`` forces remote
+        execution and ``"hybrid"`` prefers local models but falls back to a
+        cloud API when none are available.
+    """
+
+    if policy == "local":
+        return "local"
+    if policy == "cloud":
+        return "cloud"
+    # Hybrid mode prefers local models when they exist
+    if task in MODEL_REGISTRY:
+        return "local"
+    return "cloud"
+
+
 def verify_checksum(path: str | Path, expected: str) -> bool:
     """Check the SHA256 hash of ``path`` against ``expected``."""
 

--- a/tests/test_cloud_sync.py
+++ b/tests/test_cloud_sync.py
@@ -1,0 +1,34 @@
+import pytest
+from cloud_sync import CloudSync, InMemoryProvider, encrypt
+
+
+def test_sync_conflict_local(tmp_path):
+    provider = InMemoryProvider()
+    local = tmp_path / "data.txt"
+    local.write_text("local")
+    provider.upload("data", encrypt(b"remote", "pw"))
+    sync = CloudSync(provider, "pw", conflict_resolution="local")
+    action = sync.sync_file(local, "data")
+    assert action == "uploaded"
+    assert provider.download("data") == encrypt(b"local", "pw")
+
+
+def test_sync_conflict_remote(tmp_path):
+    provider = InMemoryProvider()
+    local = tmp_path / "data.txt"
+    local.write_text("local")
+    provider.upload("data", encrypt(b"remote", "pw"))
+    sync = CloudSync(provider, "pw", conflict_resolution="remote")
+    action = sync.sync_file(local, "data")
+    assert action == "downloaded"
+    assert local.read_text() == "remote"
+
+
+def test_sync_conflict_ask(tmp_path):
+    provider = InMemoryProvider()
+    local = tmp_path / "data.txt"
+    local.write_text("local")
+    provider.upload("data", encrypt(b"remote", "pw"))
+    sync = CloudSync(provider, "pw", conflict_resolution="ask")
+    with pytest.raises(RuntimeError):
+        sync.sync_file(local, "data")


### PR DESCRIPTION
## Summary
- add `cloud_sync` module with encrypted backups and conflict-resolution strategies for syncing models and profiles
- support hybrid AI by selecting local or cloud inference per task
- extend Control Center GUI with sync frequency & conflict resolution settings and document cloud sync

## Testing
- `pytest`
- `pytest tests/test_cloud_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fdd9388dc83269ccef0cfa2736e97