### PR TITLE
feat: add OS integration stubs and tests

### DIFF
--- a/control_center/backends.py
+++ b/control_center/backends.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 from typing import Protocol
 
-__all__ = ["Backend", "LocalBackend", "RemoteBackend", "load_backend"]
+__all__ = [
+    "Backend",
+    "LocalBackend",
+    "RemoteBackend",
+    "load_backend",
+    "set_context_menu",
+    "context_menu_enabled",
+]
 
 
 class Backend(Protocol):
@@ -26,6 +33,22 @@ class RemoteBackend:
 
     def generate(self, prompt: str) -> str:  # pragma: no cover - trivial
         return f"[remote] {prompt}"
+
+
+_context_menu_enabled = False
+
+
+def set_context_menu(enabled: bool) -> None:
+    """Enable or disable context menu integration."""
+
+    global _context_menu_enabled
+    _context_menu_enabled = bool(enabled)
+
+
+def context_menu_enabled() -> bool:
+    """Return whether the context menu integration is enabled."""
+
+    return _context_menu_enabled
 
 
 def load_backend(kind: str) -> Backend:

--- a/docs/os_integration.md
+++ b/docs/os_integration.md
@@ -1,0 +1,18 @@
+# Operating System Integration
+
+This project showcases several examples of how Windows AI features may
+hook into operating system components:
+
+* **Explorer integration** – `windows_ai.explorer` can reason about
+  files in a folder and suggest clean up operations.
+* **Task Manager integration** – `windows_ai.task_manager` performs
+  lightweight analysis of running processes.
+* **Context menu hooks** – registry scripts in `install/` allow adding an
+  "Ask Windows AI" entry to the Windows right‑click menu.  The toggle for
+  this feature is exposed through `control_center.backends`.
+* **GUI overlays and hotkeys** – `gui.core` includes an overlay system
+  and a simple hotkey manager that can be extended by higher level
+  applications.
+
+These modules provide isolated, testable building blocks intended to be
+wired into real Windows APIs by downstream packages.

--- a/gui/core.py
+++ b/gui/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol, List
+from typing import Protocol, List, Dict, Callable
 
 
 class Model(Protocol):
@@ -11,17 +11,47 @@ class Model(Protocol):
         raise NotImplementedError
 
 
-class GuiCore:
-    """Minimal GUI core placeholder.
+class OverlayWidget:
+    """Very small representation of an overlay widget."""
 
-    This class simulates launching a GUI application and routing chat
-    messages to a local model while keeping a simple log of events.
-    """
+    def __init__(self, name: str, content: str):
+        self.name = name
+        self.content = content
+        self.visible = False
+
+    def show(self) -> None:
+        self.visible = True
+
+    def hide(self) -> None:
+        self.visible = False
+
+
+class HotkeyManager:
+    """Register and trigger hotkey callbacks."""
+
+    def __init__(self):
+        self._handlers: Dict[str, Callable[[], None]] = {}
+
+    def register(self, combo: str, handler: Callable[[], None]) -> None:
+        self._handlers[combo] = handler
+
+    def trigger(self, combo: str) -> bool:
+        handler = self._handlers.get(combo)
+        if handler is None:
+            return False
+        handler()
+        return True
+
+
+class GuiCore:
+    """Minimal GUI core placeholder with overlays and hotkeys."""
 
     def __init__(self, model: Model):
         self.model = model
         self.launched = False
         self._logs: List[str] = []
+        self.overlays: Dict[str, OverlayWidget] = {}
+        self.hotkeys = HotkeyManager()
 
     def launch(self) -> bool:
         """Launch the GUI and record the event.
@@ -39,6 +69,27 @@ class GuiCore:
         response = self.model.generate(message)
         self._logs.append(f"chat: {message}")
         return response
+
+    def add_overlay(self, name: str, content: str) -> OverlayWidget:
+        """Create and store an overlay widget."""
+
+        widget = OverlayWidget(name, content)
+        self.overlays[name] = widget
+        return widget
+
+    def show_overlay(self, name: str) -> None:
+        self.overlays[name].show()
+
+    def hide_overlay(self, name: str) -> None:
+        self.overlays[name].hide()
+
+    def register_hotkey(self, combo: str, handler: Callable[[], None]) -> None:
+        self.hotkeys.register(combo, handler)
+
+    def handle_hotkey(self, combo: str) -> bool:
+        """Trigger a registered hotkey."""
+
+        return self.hotkeys.trigger(combo)
 
     def get_logs(self) -> List[str]:
         """Return the collected logs."""

--- a/install/context_menu_add.reg
+++ b/install/context_menu_add.reg
@@ -1,0 +1,7 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CLASSES_ROOT\*\shell\WindowsAI]
+@="Ask Windows AI"
+
+[HKEY_CLASSES_ROOT\*\shell\WindowsAI\command]
+@="\"%PROGRAMFILES%\\WindowsAI\\windows_ai.exe\" \"%1\""

--- a/install/context_menu_remove.reg
+++ b/install/context_menu_remove.reg
@@ -1,0 +1,3 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CLASSES_ROOT\*\shell\WindowsAI]

--- a/tests/test_backends_toggle.py
+++ b/tests/test_backends_toggle.py
@@ -1,0 +1,8 @@
+from control_center.backends import context_menu_enabled, set_context_menu
+
+
+def test_context_menu_toggle():
+    set_context_menu(True)
+    assert context_menu_enabled() is True
+    set_context_menu(False)
+    assert context_menu_enabled() is False

--- a/tests/test_explorer_ai.py
+++ b/tests/test_explorer_ai.py
@@ -1,0 +1,14 @@
+from windows_ai.explorer import ExplorerAI
+
+
+class DummyModel:
+    def generate(self, prompt: str) -> str:
+        return f"RESULT:{prompt}"
+
+
+def test_suggest_cleanup_records_prompt():
+    model = DummyModel()
+    explorer = ExplorerAI(model)
+    result = explorer.suggest_cleanup(["a.txt", "b.txt"])
+    assert result == "RESULT:cleanup: a.txt, b.txt"
+    assert explorer.get_logs() == ["cleanup: a.txt, b.txt"]

--- a/tests/test_gui_core.py
+++ b/tests/test_gui_core.py
@@ -14,3 +14,19 @@ def test_gui_launch_and_chat():
     logs = gui.get_logs()
     assert "GUI launched" in logs
     assert "chat: hello" in logs
+
+def test_overlays_and_hotkeys():
+    model = DummyModel()
+    gui = GuiCore(model)
+    overlay = gui.add_overlay("tip", "Hello")
+    assert overlay.visible is False
+    gui.show_overlay("tip")
+    assert overlay.visible is True
+    triggered = []
+
+    def cb():
+        triggered.append(True)
+
+    gui.register_hotkey("Ctrl+H", cb)
+    assert gui.handle_hotkey("Ctrl+H") is True
+    assert triggered

--- a/tests/test_task_manager_ai.py
+++ b/tests/test_task_manager_ai.py
@@ -1,0 +1,14 @@
+from windows_ai.task_manager import TaskManagerAI
+
+
+class DummyModel:
+    def generate(self, prompt: str) -> str:
+        return f"ANALYSIS:{prompt}"
+
+
+def test_analyze_processes_records_prompt():
+    model = DummyModel()
+    tm = TaskManagerAI(model)
+    result = tm.analyze_processes(["proc1", "proc2"])
+    assert result == "ANALYSIS:analyze: proc1, proc2"
+    assert tm.get_queries() == ["analyze: proc1, proc2"]

--- a/windows_ai/explorer.py
+++ b/windows_ai/explorer.py
@@ -1,0 +1,36 @@
+"""AI helpers for Windows Explorer integration."""
+
+from __future__ import annotations
+
+from typing import List, Any
+
+
+class ExplorerAI:
+    """Simple AI utility for working with file explorer data.
+
+    The class is intentionally small and framework agnostic.  It records
+    prompts sent to the supplied ``model`` allowing tests to assert that
+    interactions occurred without needing a real language model.
+    """
+
+    def __init__(self, model: Any):
+        self.model = model
+        self._logs: List[str] = []
+
+    def suggest_cleanup(self, files: List[str]) -> str:
+        """Return model suggestions for cleaning up *files*.
+
+        Parameters
+        ----------
+        files:
+            A list of file names that might require clean up.
+        """
+
+        prompt = "cleanup: " + ", ".join(files)
+        self._logs.append(prompt)
+        return self.model.generate(prompt)
+
+    def get_logs(self) -> List[str]:
+        """Return recorded prompts."""
+
+        return list(self._logs)

--- a/windows_ai/task_manager.py
+++ b/windows_ai/task_manager.py
@@ -1,0 +1,25 @@
+"""AI helpers for Windows Task Manager integration."""
+
+from __future__ import annotations
+
+from typing import List, Any
+
+
+class TaskManagerAI:
+    """Small helper that analyzes process lists via a model."""
+
+    def __init__(self, model: Any):
+        self.model = model
+        self._queries: List[str] = []
+
+    def analyze_processes(self, processes: List[str]) -> str:
+        """Return model analysis for the provided process names."""
+
+        prompt = "analyze: " + ", ".join(processes)
+        self._queries.append(prompt)
+        return self.model.generate(prompt)
+
+    def get_queries(self) -> List[str]:
+        """Return recorded queries."""
+
+        return list(self._queries)


### PR DESCRIPTION
## Summary
- add ExplorerAI and TaskManagerAI helpers
- wire up context menu registry hooks and backend toggles
- introduce overlay widgets and hotkey manager in GUI core
- document OS integration points
- add regression tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe8a690648326a68115d3eca58f06