### PR TITLE
Add plugin marketplace and security features

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -20,6 +20,7 @@ from . import get_plugins
 from mesh import MeshNode
 from iot import ADAPTERS, discover_devices, pair_device
 from secrets import token_urlsafe
+from plugins.manager import PluginManager
 
 try:  # pragma: no cover - optional dependency
     import qrcode  # type: ignore
@@ -102,6 +103,9 @@ class ChatGUI:
         ).pack(side="left", padx=5)
         ttk.Button(
             input_frame, text="Sync Settings", command=self._open_sync_settings
+        ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Plugins", command=self._open_plugin_marketplace
         ).pack(side="left", padx=5)
 
     # ----------------------------------------------------------------- Chat
@@ -194,6 +198,41 @@ class ChatGUI:
             )
             tk.Label(win, font=("Courier", 1), text=ascii_qr).pack(padx=5, pady=5)
         ttk.Label(win, text=f"Token: {token}").pack(padx=5, pady=5)
+
+    # -------------------------------------------------------------- Marketplace
+    def _open_plugin_marketplace(self) -> None:
+        """Simple plugin marketplace for browsing and installing plugins."""
+
+        pm = PluginManager()
+        win = tk.Toplevel(self.root)
+        win.title("Plugin Marketplace")
+
+        tree = ttk.Treeview(win, columns=("description", "rating"), show="headings")
+        tree.heading("description", text="Description")
+        tree.heading("rating", text="Rating")
+        for plugin in pm.plugins:
+            tree.insert(
+                "",
+                "end",
+                iid=plugin.name,
+                values=(plugin.description, plugin.rating or "-"),
+            )
+        tree.pack(fill="both", expand=True, padx=5, pady=5)
+
+        def install() -> None:
+            for sel in tree.selection():
+                plugin = pm.get_plugin(sel)
+                if plugin:
+                    pm.install(plugin)
+
+        def update() -> None:
+            # For now update simply reinstalls the plugin
+            install()
+
+        btn_frame = ttk.Frame(win)
+        btn_frame.pack(pady=5)
+        ttk.Button(btn_frame, text="Install", command=install).pack(side="left", padx=5)
+        ttk.Button(btn_frame, text="Update", command=update).pack(side="left", padx=5)
 
     # ----------------------------------------------------------------- Chat
     def send_message(self, event: object | None = None) -> None:

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -1,0 +1,44 @@
+# Plugin Marketplace Contribution Guide
+
+This project includes a lightweight plugin marketplace.  Plugins allow users to
+extend the Control Center with new capabilities such as model integrations or
+automation tools.  Community contributions are welcome—use the guidelines below
+to add your plugin.
+
+## Adding a Plugin
+
+1. Edit `plugins/catalog.json` and append a new entry under the `plugins`
+   array.  Each entry must provide:
+
+   - `name` – unique plugin name.
+   - `description` – short human readable summary.
+   - `command` – installation command.  Prefer absolute paths or one of the
+     approved commands (`pip`, `npm`, `brew`).
+   - `paid` – whether the plugin requires a commercial licence.
+   - `metadata` – free form dictionary with fields such as `version` or
+     `author`.
+   - `rating` – community rating between 0 and 5.
+   - `dependencies` – list of other plugin names that must be installed first.
+
+2. If your plugin distribution can be verified, include a `signature` field
+   containing the SHA256 hash of the plugin name.  This simple scheme is used
+   by the test suite to demonstrate signature verification.
+
+3. Provide accompanying documentation or usage examples where appropriate.
+
+## Testing
+
+Run the unit tests to ensure your plugin works with the manager:
+
+```bash
+pytest tests/test_plugin_manager.py
+```
+
+Plugins that fail to install or break existing tests will not be accepted.
+
+## Security
+
+Installation commands execute inside a temporary sandbox directory with a very
+limited environment.  Avoid commands that modify global system state and do not
+rely on environment variables beyond `PATH`.
+

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,6 @@
+"""Plugin package exposing the plugin manager and catalog loader."""
+
+from .manager import Plugin, PluginManager, load_catalog
+
+__all__ = ["Plugin", "PluginManager", "load_catalog"]
+

--- a/plugins/catalog.json
+++ b/plugins/catalog.json
@@ -4,19 +4,28 @@
       "name": "LangChain",
       "description": "Framework for building LLM-powered applications.",
       "command": "pip install langchain",
-      "paid": false
+      "paid": false,
+      "metadata": {"version": "0.1.0", "author": "LangChain"},
+      "rating": 4.5,
+      "dependencies": []
     },
     {
       "name": "n8n",
       "description": "Workflow automation and integration platform.",
       "command": "npm install -g n8n",
-      "paid": true
+      "paid": true,
+      "metadata": {"version": "1.2.0", "author": "n8n"},
+      "rating": 4.0,
+      "dependencies": []
     },
     {
       "name": "Warp Terminal",
       "description": "GPU-accelerated terminal with modern features.",
       "command": "brew install warp",
-      "paid": false
+      "paid": false,
+      "metadata": {"version": "0.5.0", "author": "Warp"},
+      "rating": 4.2,
+      "dependencies": []
     }
   ]
 }

--- a/plugins/manager.py
+++ b/plugins/manager.py
@@ -1,0 +1,156 @@
+"""Manage optional plugins with basic security features.
+
+This module loads plugin definitions from :mod:`plugins.catalog.json` and
+provides a :class:`PluginManager` capable of installing them.  Plugins can
+declare dependencies and include a simple integrity signature.  Installation
+commands run inside a restricted sandbox directory to avoid unexpected
+side‑effects during tests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Catalog lives alongside this file
+CATALOG_PATH = Path(__file__).resolve().parent / "catalog.json"
+# Temporary directory used for sandboxed execution
+SANDBOX_DIR = Path(tempfile.gettempdir())
+
+
+@dataclass
+class Plugin:
+    """Representation of a plugin entry in the catalog."""
+
+    name: str
+    description: str
+    command: str
+    paid: bool = False
+    metadata: dict[str, str] | None = None
+    rating: float | None = None
+    dependencies: list[str] = field(default_factory=list)
+    signature: str | None = None
+
+
+def load_catalog(path: Path = CATALOG_PATH) -> list[Plugin]:
+    """Load plugin definitions from a JSON catalog."""
+
+    path = Path(path)
+    if not path.exists():
+        return []
+
+    data = json.loads(path.read_text(encoding="utf-8") or "{}")
+    entries = data.get("plugins", []) if isinstance(data, dict) else []
+
+    plugins: list[Plugin] = []
+    for entry in entries:
+        plugins.append(
+            Plugin(
+                name=entry.get("name", ""),
+                description=entry.get("description", ""),
+                command=entry.get("command", ""),
+                paid=entry.get("paid", False),
+                metadata=entry.get("metadata"),
+                rating=entry.get("rating"),
+                dependencies=entry.get("dependencies", []),
+                signature=entry.get("signature"),
+            )
+        )
+    return plugins
+
+
+class PluginManager:
+    """Present and install plugins from the catalog."""
+
+    ALLOWED_COMMANDS = {"pip", "npm", "brew"}
+
+    def __init__(self, catalog_path: Path = CATALOG_PATH) -> None:
+        self.catalog_path = Path(catalog_path)
+        self.plugins = load_catalog(self.catalog_path)
+        self._installed: set[str] = set()
+
+    # ------------------------------------------------------------------ helpers
+    def get_plugin(self, name: str) -> Plugin | None:
+        """Return a plugin by name."""
+
+        for plugin in self.plugins:
+            if plugin.name == name:
+                return plugin
+        return None
+
+    def verify_signature(self, plugin: Plugin) -> None:
+        """Ensure a plugin's signature matches its expected value.
+
+        For simplicity we expect the signature to be the SHA256 hash of the
+        plugin name.  Real implementations would use asymmetric cryptography.
+        """
+
+        if plugin.signature is None:
+            return
+        expected = hashlib.sha256(plugin.name.encode("utf-8")).hexdigest()
+        if plugin.signature != expected:
+            raise ValueError("Invalid signature")
+
+    def sandbox_run(self, args: list[str]) -> None:
+        """Execute a command inside a restricted environment."""
+
+        subprocess.run(
+            args,
+            shell=False,
+            check=True,
+            cwd=str(SANDBOX_DIR),
+            env={"PATH": os.environ.get("PATH", "")},
+        )
+
+    # --------------------------------------------------------------- installation
+    def install(
+        self,
+        plugin: Plugin,
+        messagebox=None,
+        _stack: set[str] | None = None,
+    ) -> None:
+        """Install a plugin and its dependencies."""
+
+        if plugin.name in self._installed:
+            return
+
+        if _stack is None:
+            _stack = set()
+        if plugin.name in _stack:
+            raise ValueError("Cyclic dependency detected")
+        _stack.add(plugin.name)
+
+        # Install dependencies first
+        for dep_name in plugin.dependencies:
+            dep = self.get_plugin(dep_name)
+            if dep is None:
+                raise ValueError(f"Missing dependency: {dep_name}")
+            self.install(dep, messagebox, _stack)
+
+        _stack.remove(plugin.name)
+
+        try:
+            self.verify_signature(plugin)
+            args = shlex.split(plugin.command)
+            if not args:
+                raise ValueError("Empty command")
+            executable = Path(args[0])
+            if not executable.is_absolute() and executable.name not in self.ALLOWED_COMMANDS:
+                raise ValueError("Command not allowed")
+            self.sandbox_run(args)
+            self._installed.add(plugin.name)
+        except Exception as exc:  # pragma: no cover - subprocess path
+            if messagebox is not None:
+                messagebox.showerror("Plugin Install", f"Failed to install {plugin.name}: {exc}")
+            else:
+                raise
+
+
+__all__ = ["Plugin", "PluginManager", "load_catalog", "SANDBOX_DIR"]
+

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -1,9 +1,11 @@
+import hashlib
+import os
 import shutil
 import subprocess
 
 import pytest
 
-from installer.plugins.manager import Plugin, PluginManager, load_catalog
+from plugins.manager import SANDBOX_DIR, Plugin, PluginManager, load_catalog
 
 
 def test_catalog_loads_default_manifest():
@@ -27,10 +29,12 @@ def test_install_runs_absolute_command(monkeypatch):
 
     recorded: dict[str, object] = {}
 
-    def fake_run(args, shell, check):
+    def fake_run(args, shell, check, cwd, env):
         recorded["args"] = args
         recorded["shell"] = shell
         recorded["check"] = check
+        recorded["cwd"] = cwd
+        recorded["env"] = env
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     manager.install(plugin)
@@ -38,6 +42,8 @@ def test_install_runs_absolute_command(monkeypatch):
     assert recorded["args"] == [echo_path, "hello"]
     assert recorded["shell"] is False
     assert recorded["check"] is True
+    assert recorded["cwd"] == str(SANDBOX_DIR)
+    assert recorded["env"] == {"PATH": os.environ.get("PATH", "")}
 
 
 def test_install_rejects_unsafe_command():
@@ -45,3 +51,45 @@ def test_install_rejects_unsafe_command():
     manager = PluginManager()
     with pytest.raises(ValueError):
         manager.install(plugin)
+
+
+def test_install_rejects_bad_signature():
+    echo_path = shutil.which("echo")
+    assert echo_path
+    plugin = Plugin(
+        name="Signed", description="", command=f"{echo_path} hi", signature="deadbeef"
+    )
+    manager = PluginManager()
+    with pytest.raises(ValueError):
+        manager.install(plugin)
+
+
+def test_dependencies_install_first(monkeypatch):
+    echo_path = shutil.which("echo")
+    assert echo_path
+    dep = Plugin(
+        name="Dep",
+        description="",
+        command=f"{echo_path} dep",
+        signature=hashlib.sha256("Dep".encode()).hexdigest(),
+    )
+    main = Plugin(
+        name="Main",
+        description="",
+        command=f"{echo_path} main",
+        dependencies=["Dep"],
+        signature=hashlib.sha256("Main".encode()).hexdigest(),
+    )
+    manager = PluginManager()
+    manager.plugins = [dep, main]
+
+    calls: list[list[str]] = []
+
+    def fake_run(args, shell, check, cwd, env):
+        calls.append(args)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    manager.install(main)
+
+    assert calls == [[echo_path, "dep"], [echo_path, "main"]]
+


### PR DESCRIPTION
## Summary
- extend plugin catalog schema with metadata, ratings and dependencies
- add marketplace UI for browsing and installing plugins
- add plugin manager with signature verification and sandboxed command execution
- document contribution guidelines and expand plugin manager tests

## Testing
- `pytest tests/test_plugin_manager.py tests/test_control_center_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_688fea457b688326aa44dff60200ce0e