### PR TITLE
Add security package and GUI for plugin permissions

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -21,6 +21,7 @@ from mesh import MeshNode
 from iot import ADAPTERS, discover_devices, pair_device
 from secrets import token_urlsafe
 from plugins.manager import PluginManager
+from security import AuditLogger, PermissionManager
 
 try:  # pragma: no cover - optional dependency
     import qrcode  # type: ignore
@@ -55,6 +56,9 @@ class ChatGUI:
         # Sync settings
         self.sync_frequency = 60  # minutes
         self.conflict_resolution = "ask"
+        # Security
+        self.audit_logger = AuditLogger()
+        self.permission_manager = PermissionManager(audit_logger=self.audit_logger)
 
         self._build_widgets()
 
@@ -106,6 +110,12 @@ class ChatGUI:
         ).pack(side="left", padx=5)
         ttk.Button(
             input_frame, text="Plugins", command=self._open_plugin_marketplace
+        ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Permissions", command=self._open_plugin_permissions
+        ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Logs", command=self._open_audit_log
         ).pack(side="left", padx=5)
 
     # ----------------------------------------------------------------- Chat
@@ -233,6 +243,61 @@ class ChatGUI:
         btn_frame.pack(pady=5)
         ttk.Button(btn_frame, text="Install", command=install).pack(side="left", padx=5)
         ttk.Button(btn_frame, text="Update", command=update).pack(side="left", padx=5)
+
+    # ----------------------------------------------------------- Permissions
+    def _open_plugin_permissions(self) -> None:
+        """Configure permissions for individual plugins."""
+
+        pm = PluginManager()
+        win = tk.Toplevel(self.root)
+        win.title("Plugin Permissions")
+
+        listbox = tk.Listbox(win, height=6)
+        listbox.pack(side="left", fill="y", padx=5, pady=5)
+        for plugin in pm.plugins:
+            listbox.insert("end", plugin.name)
+
+        check_frame = ttk.Frame(win)
+        check_frame.pack(side="left", fill="both", expand=True, padx=5, pady=5)
+        network_var = tk.BooleanVar()
+        fs_var = tk.BooleanVar()
+        ttk.Checkbutton(check_frame, text="Network", variable=network_var).pack(anchor="w")
+        ttk.Checkbutton(check_frame, text="Filesystem", variable=fs_var).pack(anchor="w")
+
+        def update_checks(event: object | None = None) -> None:
+            if not listbox.curselection():
+                return
+            name = listbox.get(listbox.curselection()[0])
+            perms = self.permission_manager.permissions.get(name, set())
+            network_var.set("network" in perms)
+            fs_var.set("filesystem" in perms)
+
+        def save() -> None:
+            if not listbox.curselection():
+                return
+            name = listbox.get(listbox.curselection()[0])
+            if network_var.get():
+                self.permission_manager.grant(name, "network")
+            else:
+                self.permission_manager.revoke(name, "network")
+            if fs_var.get():
+                self.permission_manager.grant(name, "filesystem")
+            else:
+                self.permission_manager.revoke(name, "filesystem")
+
+        listbox.bind("<<ListboxSelect>>", update_checks)
+        ttk.Button(check_frame, text="Save", command=save).pack(pady=5)
+
+    # --------------------------------------------------------------- Log view
+    def _open_audit_log(self) -> None:
+        """Display the contents of the audit log."""
+
+        win = tk.Toplevel(self.root)
+        win.title("Audit Log")
+        text = tk.Text(win, wrap="word", height=20, width=80)
+        text.pack(fill="both", expand=True, padx=5, pady=5)
+        text.insert("end", self.audit_logger.read())
+        text.config(state="disabled")
 
     # ----------------------------------------------------------------- Chat
     def send_message(self, event: object | None = None) -> None:

--- a/docs/security_privacy.md
+++ b/docs/security_privacy.md
@@ -1,0 +1,18 @@
+# Security and Privacy
+
+The project ships with a small `security` package providing:
+
+- **Permission models** – plugins can request capabilities such as network or
+  filesystem access.  The :class:`security.permissions.PermissionManager`
+  records grants and rejections.
+- **Audit logging** – all permission checks are written to an audit log via
+  :class:`security.audit.AuditLogger` and can be reviewed from the Control
+  Center GUI.
+- **Encryption utilities** – the :mod:`security.crypto` module contains
+  lightweight helpers for encrypting and decrypting small pieces of data.
+- **Threat monitoring** – :mod:`security.threat_monitor` offers a keyword based
+  detector that mimics LLM powered heuristics for spotting suspicious activity.
+
+These features are designed for demonstration purposes and are intentionally
+minimalistic; real deployments should replace them with production ready
+implementations.

--- a/security/__init__.py
+++ b/security/__init__.py
@@ -1,0 +1,14 @@
+"""Security utilities including permissions, audit logging and crypto."""
+
+from .permissions import PermissionManager
+from .audit import AuditLogger
+from .crypto import encrypt, decrypt
+from .threat_monitor import ThreatMonitor
+
+__all__ = [
+    "PermissionManager",
+    "AuditLogger",
+    "encrypt",
+    "decrypt",
+    "ThreatMonitor",
+]

--- a/security/audit.py
+++ b/security/audit.py
@@ -1,0 +1,33 @@
+"""Simple audit logging utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass
+class AuditLogger:
+    """Record security related events to a log file."""
+
+    path: Path | str | None = None
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path or Path("audit.log"))
+
+    # -------------------------------------------------------------- utilities
+    def log(self, plugin: str, action: str, permission: str) -> None:
+        """Append an entry to the audit log."""
+
+        line = f"{datetime.utcnow().isoformat()} {plugin} {action} {permission}\n"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+
+    def read(self) -> str:
+        """Return the full audit log as a string."""
+
+        if not self.path.exists():
+            return ""
+        return self.path.read_text(encoding="utf-8")

--- a/security/crypto.py
+++ b/security/crypto.py
@@ -1,0 +1,32 @@
+"""Lightweight encryption helpers.
+
+These helpers use a very small XOR cipher combined with base64 encoding.
+They are **not** meant for production use but serve to illustrate how
+encryption utilities could be structured.
+"""
+
+from __future__ import annotations
+
+import base64
+
+
+def _xor(data: bytes, key: bytes) -> bytes:
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+
+
+def encrypt(text: str, key: str) -> str:
+    """Encrypt ``text`` using ``key`` and return a base64 token."""
+
+    token = _xor(text.encode("utf-8"), key.encode("utf-8"))
+    return base64.b64encode(token).decode("ascii")
+
+
+def decrypt(token: str, key: str) -> str:
+    """Decrypt a base64 token produced by :func:`encrypt`."""
+
+    data = base64.b64decode(token.encode("ascii"))
+    plain = _xor(data, key.encode("utf-8"))
+    return plain.decode("utf-8")
+
+
+__all__ = ["encrypt", "decrypt"]

--- a/security/permissions.py
+++ b/security/permissions.py
@@ -1,0 +1,42 @@
+"""Permission management for plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Set
+
+from .audit import AuditLogger
+
+
+@dataclass
+class PermissionManager:
+    """Keep track of plugin permissions and enforce them."""
+
+    permissions: Dict[str, Set[str]] = field(default_factory=dict)
+    audit_logger: AuditLogger | None = None
+
+    # --------------------------------------------------------------- management
+    def grant(self, plugin: str, permission: str) -> None:
+        self.permissions.setdefault(plugin, set()).add(permission)
+        if self.audit_logger:
+            self.audit_logger.log(plugin, "GRANT", permission)
+
+    def revoke(self, plugin: str, permission: str) -> None:
+        if plugin in self.permissions:
+            self.permissions[plugin].discard(permission)
+        if self.audit_logger:
+            self.audit_logger.log(plugin, "REVOKE", permission)
+
+    # ----------------------------------------------------------------- checking
+    def has(self, plugin: str, permission: str) -> bool:
+        return permission in self.permissions.get(plugin, set())
+
+    def require(self, plugin: str, permission: str) -> None:
+        """Ensure a plugin possesses a given permission."""
+
+        if not self.has(plugin, permission):
+            if self.audit_logger:
+                self.audit_logger.log(plugin, "DENIED", permission)
+            raise PermissionError(f"{plugin} lacks {permission} permission")
+        if self.audit_logger:
+            self.audit_logger.log(plugin, "ALLOW", permission)

--- a/security/threat_monitor.py
+++ b/security/threat_monitor.py
@@ -1,0 +1,27 @@
+"""Basic threat monitoring using heuristic checks.
+
+In a real deployment this module could leverage an external LLM service to
+assess logs or user activity.  For the purposes of the tests we implement a
+lightweight keyword based detector that mimics an LLM driven system.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+@dataclass
+class ThreatMonitor:
+    """Simple heuristic threat detector."""
+
+    keywords: Iterable[str] = field(
+        default_factory=lambda: ["attack", "exploit", "malware", "phishing"]
+    )
+
+    def analyze(self, text: str) -> List[str]:
+        """Return a list of suspicious keywords found in ``text``."""
+
+        hits = [kw for kw in self.keywords if re.search(rf"\b{re.escape(kw)}\b", text, re.I)]
+        return hits

--- a/tests/test_security_permissions.py
+++ b/tests/test_security_permissions.py
@@ -1,0 +1,18 @@
+import pytest
+
+from security import AuditLogger, PermissionManager
+
+
+def test_permission_enforcement(tmp_path):
+    log_path = tmp_path / "audit.log"
+    logger = AuditLogger(log_path)
+    manager = PermissionManager(audit_logger=logger)
+
+    manager.grant("PluginA", "network")
+    manager.require("PluginA", "network")  # should not raise
+
+    with pytest.raises(PermissionError):
+        manager.require("PluginA", "filesystem")
+
+    log = log_path.read_text(encoding="utf-8")
+    assert "DENIED" in log and "filesystem" in log


### PR DESCRIPTION
## Summary
- add `security` package with permission manager, audit logger, crypto helpers and threat monitor
- expose plugin permission and audit log panels in Control Center GUI
- document security features and cover permission checks with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688febd641888326a7af57d7c1a80e77