### PR TITLE
feat: add pluggable universal search

### DIFF
--- a/config/search.yaml
+++ b/config/search.yaml
@@ -1,0 +1,5 @@
+backend: local
+local:
+  storage_path: data/search_index.json
+cloud:
+  endpoint: https://example.com/search

--- a/docs/universal_search.md
+++ b/docs/universal_search.md
@@ -1,0 +1,43 @@
+# Universal Search
+
+The universal search system provides a simple token-based index that can be
+used to look up local files or trigger actions from the GUI.
+
+## Configuration
+
+Select the backend by editing `config/search.yaml`:
+
+```yaml
+backend: local  # or "cloud"
+cloud:
+  endpoint: https://example.com/search
+```
+
+The local backend keeps an in-memory index. The cloud backend represents a
+remote service and is intended to be replaced with a real implementation.
+
+## Using the GUI
+
+```python
+from search import load_engine
+from gui.core import GuiCore
+
+engine = load_engine()
+engine.index({"readme": "Open the README file"})
+
+gui = GuiCore(model)
+gui.enable_search(engine)
+results = gui.search("readme")
+
+# Link search results to actions
+
+def open_readme():
+    print("Opening README.md")
+
+gui.register_search_action("readme", open_readme)
+if "readme" in results:
+    gui.activate_search_result("readme")
+```
+
+This example indexes a small document, queries it from the GUI and associates a
+workflow with the returned result.

--- a/gui/core.py
+++ b/gui/core.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Protocol, List, Dict, Callable
+from typing import Protocol, List, Dict, Callable, Optional
+
+from search import SearchEngine
 
 
 class Model(Protocol):
@@ -52,6 +54,8 @@ class GuiCore:
         self._logs: List[str] = []
         self.overlays: Dict[str, OverlayWidget] = {}
         self.hotkeys = HotkeyManager()
+        self.search_engine: Optional[SearchEngine] = None
+        self._search_actions: Dict[str, Callable[[], None]] = {}
 
     def launch(self) -> bool:
         """Launch the GUI and record the event.
@@ -95,3 +99,37 @@ class GuiCore:
         """Return the collected logs."""
 
         return list(self._logs)
+
+    # ---- search integration -------------------------------------------------
+
+    def enable_search(self, engine: SearchEngine) -> None:
+        """Attach a search engine and prepare the search overlay."""
+
+        self.search_engine = engine
+        self.add_overlay("search", "")
+
+    def search(self, query: str) -> List[str]:
+        """Execute a query and display results in the search overlay."""
+
+        if self.search_engine is None:
+            return []
+        results = self.search_engine.search(query)
+        overlay = self.overlays.get("search")
+        if overlay:
+            overlay.content = "\n".join(results)
+            overlay.show()
+        return results
+
+    def register_search_action(self, result_id: str, action: Callable[[], None]) -> None:
+        """Link a search result to an executable action."""
+
+        self._search_actions[result_id] = action
+
+    def activate_search_result(self, result_id: str) -> bool:
+        """Execute the action associated with a search result."""
+
+        action = self._search_actions.get(result_id)
+        if action is None:
+            return False
+        action()
+        return True

--- a/search/__init__.py
+++ b/search/__init__.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import yaml
+
+from .backends import LocalBackend, CloudBackend, SearchBackend
+
+
+@dataclass
+class SearchEngine:
+    """Wrapper around a pluggable search backend."""
+
+    backend: SearchBackend
+
+    def index(self, docs: Dict[str, str]) -> None:
+        self.backend.index(docs)
+
+    def search(self, query: str, top_k: int = 5):
+        return self.backend.search(query, top_k=top_k)
+
+
+def load_engine(config_path: str = "config/search.yaml") -> SearchEngine:
+    """Create a search engine from the provided configuration file."""
+
+    with open(config_path, "r") as f:
+        cfg = yaml.safe_load(f) or {}
+
+    backend_name = cfg.get("backend", "local")
+    if backend_name == "cloud":
+        endpoint = cfg.get("cloud", {}).get("endpoint", "")
+        backend = CloudBackend(endpoint)
+    else:
+        backend = LocalBackend()
+    return SearchEngine(backend)
+
+__all__ = ["SearchEngine", "load_engine", "LocalBackend", "CloudBackend"]

--- a/search/backends.py
+++ b/search/backends.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .embeddings import embed
+from .index import SearchIndex
+
+
+class SearchBackend:
+    """Abstract search backend interface."""
+
+    def index(self, docs: Dict[str, str]) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def search(self, query: str, top_k: int = 5) -> List[str]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class LocalBackend(SearchBackend):
+    """Simple in-memory search backend."""
+
+    def __init__(self):
+        self._index = SearchIndex(embed)
+
+    def index(self, docs: Dict[str, str]) -> None:
+        for doc_id, text in docs.items():
+            self._index.add_document(doc_id, text)
+
+    def search(self, query: str, top_k: int = 5) -> List[str]:
+        return self._index.query(query, top_k=top_k)
+
+
+class CloudBackend(SearchBackend):
+    """Placeholder backend representing a remote service."""
+
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+        self._indexed: Dict[str, str] = {}
+
+    def index(self, docs: Dict[str, str]) -> None:
+        # In a real implementation this would send docs to the service.
+        self._indexed.update(docs)
+
+    def search(self, query: str, top_k: int = 5) -> List[str]:
+        # Real implementation would call the remote service. We return all ids
+        # when a query is provided to keep behaviour deterministic for tests.
+        if not query:
+            return []
+        return list(self._indexed.keys())[:top_k]

--- a/search/embeddings.py
+++ b/search/embeddings.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Set
+
+
+def embed(text: str) -> Set[str]:
+    """Very small token-based embedding.
+
+    The function lowercases the text and splits on whitespace, returning a
+    set of tokens that can be used for similarity search."""
+
+    return set(text.lower().split())

--- a/search/index.py
+++ b/search/index.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Dict, List, Set, Callable
+
+
+class SearchIndex:
+    """In-memory search index using simple token embeddings."""
+
+    def __init__(self, embed_fn: Callable[[str], Set[str]]):
+        self._embed = embed_fn
+        self._docs: Dict[str, Set[str]] = {}
+
+    def add_document(self, doc_id: str, text: str) -> None:
+        """Add or update a document in the index."""
+
+        self._docs[doc_id] = self._embed(text)
+
+    def query(self, text: str, top_k: int = 5) -> List[str]:
+        """Return document ids ranked by token overlap."""
+
+        q_vec = self._embed(text)
+        scores = []
+        for doc_id, vec in self._docs.items():
+            score = len(q_vec & vec)
+            if score > 0:
+                scores.append((score, doc_id))
+        scores.sort(reverse=True)
+        return [doc_id for score, doc_id in scores[:top_k]]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,29 @@
+from search import SearchEngine, LocalBackend
+from gui.core import GuiCore
+
+
+class DummyModel:
+    def generate(self, prompt: str) -> str:
+        return prompt.upper()
+
+
+def test_search_index_and_query():
+    backend = LocalBackend()
+    engine = SearchEngine(backend)
+    engine.index({"a": "hello world", "b": "foo bar"})
+    assert engine.search("hello") == ["a"]
+
+
+def test_gui_search_integration():
+    backend = LocalBackend()
+    engine = SearchEngine(backend)
+    engine.index({"file1": "open sesame"})
+    gui = GuiCore(DummyModel())
+    gui.enable_search(engine)
+    triggered = []
+    gui.register_search_action("file1", lambda: triggered.append(True))
+    results = gui.search("sesame")
+    assert results == ["file1"]
+    assert gui.overlays["search"].visible is True
+    assert gui.activate_search_result("file1") is True
+    assert triggered == [True]


### PR DESCRIPTION
## Summary
- add token-based search package with configurable backends
- wire GUI core to search engine and allow action bindings
- document universal search usage and config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688feda3463c83268330f2a15e19e9e6