### PR TITLE
Add accessibility feature detection and hooks

### DIFF
--- a/control_center/chat_ui.py
+++ b/control_center/chat_ui.py
@@ -7,7 +7,7 @@ logic to be unit tested.
 """
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 try:  # pragma: no cover - executed only when tkinter is available
     import tkinter as tk
@@ -44,6 +44,8 @@ class ChatUI:
         self.node_var: Optional["tk.StringVar"] = None
         self.entry: Optional[ttk.Entry] = None
         self.chat: Optional[tk.Text] = None
+        self._voice_handler: Optional[Callable[[str], None]] = None
+        self._alt_input_handler: Optional[Callable[[str], None]] = None
 
         if build and tk is not None:
             try:
@@ -114,6 +116,35 @@ class ChatUI:
     def run(self) -> None:  # pragma: no cover - GUI loop
         if self.root is not None:
             self.root.mainloop()
+
+    # ------------------------------------------------------- Accessibility hooks
+    def register_voice_handler(self, handler: Callable[[str], None]) -> None:
+        """Register a callback invoked with recognised voice commands."""
+
+        self._voice_handler = handler
+
+    def handle_voice_command(self, command: str) -> None:
+        """Process a voice command by delegating to the registered handler."""
+
+        if self._voice_handler is not None:
+            self._voice_handler(command)
+        elif self.entry is not None:
+            # Fallback: treat voice command as text input
+            self.entry.insert(0, command)
+            self.send_message()
+
+    def register_alt_input(self, handler: Callable[[str], None]) -> None:
+        """Register an alternative input handler for accessibility devices."""
+
+        self._alt_input_handler = handler
+
+    def receive_alt_input(self, data: str) -> None:
+        """Send text from an alternative input source to the chat UI."""
+
+        if self._alt_input_handler is not None:
+            self._alt_input_handler(data)
+        elif self.entry is not None:
+            self.entry.insert(0, data)
 
 
 def main() -> None:  # pragma: no cover - CLI helper

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,28 @@
+# Accessibility Features
+
+Windows-AI provides basic hooks that allow the user interface to adapt to
+system-level accessibility preferences.
+
+## System Information
+
+`windows_ai.system_info.detect_system()` now reports whether a screen reader or
+high-contrast theme is enabled in the host operating system.  The function
+falls back to sensible defaults when the platform does not expose the required
+APIs.
+
+## Themes
+
+`ui.themes.ThemeManager` exposes an ``apply_accessibility`` helper which toggles
+screen reader descriptions and selects a bundled high-contrast theme.  Themes
+may include human friendly descriptions for UI elements so screen readers can
+describe controls to the user.
+
+## Control Center
+
+`control_center.chat_ui.ChatUI` provides hooks for registering voice control
+handlers and alternative input devices.  Voice commands can be processed or
+translated into chat messages, and accessibility devices can inject text directly
+into the chat interface.
+
+These features form the foundation for broader accessibility support and are
+intended to be extended by downstream applications.

--- a/tests/test_chat_ui_accessibility.py
+++ b/tests/test_chat_ui_accessibility.py
@@ -1,0 +1,20 @@
+from control_center.chat_ui import ChatUI
+
+
+def test_voice_and_alt_input_hooks():
+    ui = ChatUI(build=False)
+    called = {}
+
+    def voice(cmd: str) -> None:
+        called['voice'] = cmd
+
+    ui.register_voice_handler(voice)
+    ui.handle_voice_command('hello')
+    assert called['voice'] == 'hello'
+
+    def alt(data: str) -> None:
+        called['alt'] = data
+
+    ui.register_alt_input(alt)
+    ui.receive_alt_input('world')
+    assert called['alt'] == 'world'

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -5,3 +5,4 @@ def test_detect_system_non_windows():
     assert info["cpu_count"] > 0
     # CI runners expose a virtual GPU string; just ensure field present
     assert "gpu_name" in info and info["gpu_name"] is not None
+    assert "screen_reader" in info and "high_contrast" in info

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -9,3 +9,11 @@ def test_theme_manager():
     manager.add_keyset(keyset)
     assert manager.get_theme("dark") == theme
     assert manager.get_keyset("vim") == keyset
+
+
+def test_accessibility_theme_selection():
+    manager = ThemeManager()
+    manager.add_theme(Theme(name="light", background="#fff", foreground="#000"))
+    theme = manager.apply_accessibility(screen_reader=True, high_contrast=True)
+    assert theme is not None and theme.name == "high_contrast"
+    assert manager.screen_reader_enabled is True

--- a/ui/themes.py
+++ b/ui/themes.py
@@ -9,6 +9,15 @@ class Theme:
     name: str
     background: str
     foreground: str
+    # Optional human friendly descriptions for screen readers.
+    descriptions: Optional[Dict[str, str]] = None
+
+    def describe(self, element: str) -> Optional[str]:
+        """Return a screen reader description for ``element`` if available."""
+
+        if self.descriptions is None:
+            return None
+        return self.descriptions.get(element)
 
 
 @dataclass
@@ -23,6 +32,12 @@ class ThemeManager:
     def __init__(self):
         self._themes: Dict[str, Theme] = {}
         self._keysets: Dict[str, Keyset] = {}
+        self.screen_reader_enabled: bool = False
+
+        # Provide a built-in high contrast theme that can be selected when the
+        # operating system requests it.  Users may override it by adding a
+        # theme with the same name.
+        self.add_theme(Theme(name="high_contrast", background="#000", foreground="#fff"))
 
     def add_theme(self, theme: Theme) -> None:
         self._themes[theme.name] = theme
@@ -35,3 +50,22 @@ class ThemeManager:
 
     def get_keyset(self, name: str) -> Optional[Keyset]:
         return self._keysets.get(name)
+
+    # -------------------------------------------------------------- Accessibility
+    def apply_accessibility(
+        self, screen_reader: bool = False, high_contrast: bool = False
+    ) -> Optional[Theme]:
+        """Enable accessibility features and return the selected theme.
+
+        ``screen_reader`` toggles exposure of screen reader descriptions while
+        ``high_contrast`` chooses the bundled high-contrast theme when
+        available.  The method returns the chosen theme so callers can react to
+        the change.
+        """
+
+        self.screen_reader_enabled = screen_reader
+        if high_contrast:
+            theme = self._themes.get("high_contrast")
+            if theme:
+                return theme
+        return None

--- a/windows_ai/system_info.py
+++ b/windows_ai/system_info.py
@@ -1,12 +1,138 @@
-"""Expose system information utilities to tests and consumers."""
+"""Expose system information utilities to tests and consumers.
+
+This module wraps :func:`installer.system_info.detect_system` and augments the
+result with a best-effort lookup of operating system accessibility settings.
+The goal is to expose features like screen reader usage or high-contrast
+themes to higher level components so they can adapt their behaviour
+accordingly.  The implementation is intentionally forgiving – failures to
+query the platform are silently ignored and sensible defaults are returned
+instead.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import platform
+import subprocess
+from typing import Any, Dict
 
 from installer.system_info import detect_system as _detect_system
 
 
-def detect_system():
-    """Return system information ensuring GPU name field is populated."""
+def _detect_accessibility() -> Dict[str, bool]:
+    """Return a dictionary describing basic OS accessibility settings.
 
-    info = _detect_system()
+    The keys ``screen_reader`` and ``high_contrast`` are provided.  When the
+    settings cannot be detected the values default to ``False``.  Only a small
+    subset of platforms are supported but the function is written to fail
+    silently so it can run in minimal test environments.
+    """
+
+    settings: Dict[str, bool] = {
+        "screen_reader": False,
+        "high_contrast": False,
+    }
+
+    system = platform.system()
+    if system == "Windows":
+        try:  # pragma: no cover - Windows only
+            SPI_GETSCREENREADER = 0x0046
+            SPI_GETHIGHCONTRAST = 0x0042
+            HCF_HIGHCONTRASTON = 0x00000001
+
+            screen_reader = ctypes.c_uint()
+            ctypes.windll.user32.SystemParametersInfoW(
+                SPI_GETSCREENREADER, 0, ctypes.byref(screen_reader), 0
+            )
+            settings["screen_reader"] = bool(screen_reader.value)
+
+            class HIGHCONTRAST(ctypes.Structure):
+                _fields_ = [
+                    ("cbSize", ctypes.c_uint),
+                    ("dwFlags", ctypes.c_uint),
+                    ("lpszDefaultScheme", ctypes.c_wchar_p),
+                ]
+
+            hc = HIGHCONTRAST()
+            hc.cbSize = ctypes.sizeof(HIGHCONTRAST)
+            ctypes.windll.user32.SystemParametersInfoW(
+                SPI_GETHIGHCONTRAST, hc.cbSize, ctypes.byref(hc), 0
+            )
+            settings["high_contrast"] = bool(hc.dwFlags & HCF_HIGHCONTRASTON)
+        except Exception:
+            pass
+    elif system == "Darwin":
+        try:  # pragma: no cover - macOS only
+            out = subprocess.check_output(
+                [
+                    "defaults",
+                    "read",
+                    "com.apple.universalaccess",
+                    "VoiceOverEnabled",
+                ]
+            )
+            settings["screen_reader"] = out.strip() == b"1"
+        except Exception:
+            pass
+        try:
+            out = subprocess.check_output(
+                [
+                    "defaults",
+                    "read",
+                    "com.apple.universalaccess",
+                    "increaseContrast",
+                ]
+            )
+            settings["high_contrast"] = out.strip() == b"1"
+        except Exception:
+            pass
+    else:  # Linux/other
+        try:  # pragma: no cover - optional dependencies
+            out = subprocess.check_output(
+                [
+                    "gsettings",
+                    "get",
+                    "org.gnome.desktop.interface",
+                    "high-contrast",
+                ],
+                stderr=subprocess.DEVNULL,
+            )
+            settings["high_contrast"] = out.decode().strip().lower() in {
+                "true",
+                "1",
+            }
+        except Exception:
+            pass
+        try:
+            out = subprocess.check_output(
+                [
+                    "gsettings",
+                    "get",
+                    "org.gnome.desktop.a11y.applications",
+                    "screen-reader-enabled",
+                ],
+                stderr=subprocess.DEVNULL,
+            )
+            settings["screen_reader"] = out.decode().strip().lower() in {
+                "true",
+                "1",
+            }
+        except Exception:
+            pass
+
+    return settings
+
+
+def detect_system() -> Dict[str, Any]:
+    """Return system information including basic accessibility settings."""
+
+    info: Dict[str, Any] = _detect_system()
     if info.get("gpu_name") is None:
         info["gpu_name"] = "unknown"
+
+    info.update(_detect_accessibility())
     return info
+
+
+__all__ = ["detect_system"]
+


### PR DESCRIPTION
## Summary
- detect OS screen reader and high-contrast settings in `windows_ai.system_info`
- extend `ui.themes` with screen reader descriptions, high-contrast theme and accessibility API
- add voice control and alternative input hooks to `control_center.ChatUI`
- document accessibility capabilities and add tests

## Testing
- `pytest tests/test_system_info.py tests/test_themes.py tests/test_chat_ui_accessibility.py tests/test_chat_ui_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_688ff80f45988326a5db83ae0ff0f323