### PR TITLE
Add optimization profiles and tuning utilities

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -22,6 +22,7 @@ from iot import ADAPTERS, discover_devices, pair_device
 from secrets import token_urlsafe
 from plugins.manager import PluginManager
 from security import AuditLogger, PermissionManager
+from optimization import tuning
 
 try:  # pragma: no cover - optional dependency
     import qrcode  # type: ignore
@@ -89,6 +90,23 @@ class ChatGUI:
         )
         selector.pack(side="left")
 
+        ttk.Label(input_frame, text="Profile:").pack(side="left", padx=5)
+        self.profile_var = tk.StringVar(value="balanced")
+        profile_selector = ttk.Combobox(
+            input_frame,
+            textvariable=self.profile_var,
+            values=list(tuning.PROFILES),
+            state="readonly",
+            width=12,
+        )
+        profile_selector.pack(side="left")
+        ttk.Button(input_frame, text="Apply", command=self.apply_profile).pack(
+            side="left", padx=5
+        )
+        ttk.Button(input_frame, text="Revert", command=self.revert_profile).pack(
+            side="left", padx=5
+        )
+
         self.entry = ttk.Entry(input_frame)
         self.entry.pack(side="left", fill="x", expand=True, padx=5)
         self.entry.bind("<Return>", self.send_message)
@@ -120,6 +138,19 @@ class ChatGUI:
         ttk.Button(
             input_frame, text="Automation", command=self._open_automation_builder
         ).pack(side="left", padx=5)
+
+    def apply_profile(self) -> None:
+        """Apply the selected optimization profile."""
+        profile = self.profile_var.get()
+        tuning.apply(profile)
+        self.chat.insert("end", f"[Optimization] Applied {profile} profile\n")
+        self.chat.see("end")
+
+    def revert_profile(self) -> None:
+        """Revert to the previous optimization profile."""
+        tuning.revert()
+        self.chat.insert("end", "[Optimization] Reverted profile\n")
+        self.chat.see("end")
 
     # ----------------------------------------------------------------- Chat
     def _open_mesh_config(self) -> None:

--- a/optimization/__init__.py
+++ b/optimization/__init__.py
@@ -1,0 +1,12 @@
+"""Optimization utilities for hardware profiling and tuning."""
+
+from .profiling import profile_hardware
+from .tuning import Tuner, apply, revert, PROFILES
+
+__all__ = [
+    "profile_hardware",
+    "Tuner",
+    "apply",
+    "revert",
+    "PROFILES",
+]

--- a/optimization/explanations.md
+++ b/optimization/explanations.md
@@ -1,0 +1,11 @@
+# Optimization Profiles
+
+The optimization module provides three hardware tuning profiles:
+
+- **balanced** – default settings for everyday workloads.
+- **performance** – maximizes speed at the cost of extra power usage.
+- **eco** – reduces performance for better battery life.
+
+Each profile adjusts CPU and GPU tuning parameters. The module keeps track of
+previous settings so users can call `revert()` to return to the earlier
+configuration.

--- a/optimization/profiling.py
+++ b/optimization/profiling.py
@@ -1,0 +1,17 @@
+"""Hardware profiling helpers."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def profile_hardware() -> Dict[str, str]:
+    """Return a simple profile of available hardware.
+
+    This stub demonstrates how hardware profiling might work. In a real
+    application this would gather CPU, GPU and other metrics.
+    """
+    return {
+        "cpu": "generic",
+        "gpu": "generic",
+    }

--- a/optimization/tuning.py
+++ b/optimization/tuning.py
@@ -1,0 +1,54 @@
+"""Hardware tuning utilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+PROFILES: Dict[str, Dict[str, str]] = {
+    "balanced": {"cpu": "medium", "gpu": "medium"},
+    "performance": {"cpu": "high", "gpu": "high"},
+    "eco": {"cpu": "low", "gpu": "low"},
+}
+
+
+class Tuner:
+    """Apply and revert hardware tuning profiles."""
+
+    def __init__(self) -> None:
+        self.current_settings: Dict[str, str] = PROFILES["balanced"].copy()
+        self.previous_settings: Dict[str, str] | None = None
+
+    def apply(self, profile: str) -> Dict[str, str]:
+        """Apply a profile and store previous settings."""
+        if profile not in PROFILES:
+            raise ValueError(f"Unknown profile: {profile}")
+        logger.info("Applying %s profile", profile)
+        self.previous_settings = self.current_settings.copy()
+        self.current_settings = PROFILES[profile].copy()
+        return self.current_settings
+
+    def revert(self) -> Dict[str, str]:
+        """Revert to the previously applied profile."""
+        if self.previous_settings is not None:
+            logger.info("Reverting to previous profile")
+            self.current_settings, self.previous_settings = (
+                self.previous_settings,
+                None,
+            )
+        return self.current_settings
+
+
+tuner = Tuner()
+
+
+def apply(profile: str) -> Dict[str, str]:
+    """Apply a tuning profile using the default tuner."""
+    return tuner.apply(profile)
+
+
+def revert() -> Dict[str, str]:
+    """Revert to the previous tuning profile using the default tuner."""
+    return tuner.revert()

--- a/tests/test_tuning.py
+++ b/tests/test_tuning.py
@@ -1,0 +1,17 @@
+from optimization.tuning import Tuner, PROFILES
+
+
+def test_apply_and_revert_profile():
+    tuner = Tuner()
+    original = tuner.current_settings.copy()
+    tuner.apply("performance")
+    assert tuner.current_settings == PROFILES["performance"]
+    tuner.revert()
+    assert tuner.current_settings == original
+
+
+def test_revert_without_apply_is_noop():
+    tuner = Tuner()
+    original = tuner.current_settings.copy()
+    tuner.revert()
+    assert tuner.current_settings == original


### PR DESCRIPTION
## Summary
- Introduce `optimization` package with hardware profiling and tuning helpers
- Support Balanced, Performance and Eco profiles in Control Center GUI
- Document optimization profiles and add tests for tuning revert

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ff9a13bbc8326b18f3518291152b0