### PR TITLE
feat: enterprise session, dashboard sharing, and compliance logs

### DIFF
--- a/control_center/backends.py
+++ b/control_center/backends.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from dataclasses import dataclass, field
+from secrets import token_urlsafe
+from typing import Dict, List, Protocol, Tuple
 
 __all__ = [
     "Backend",
     "LocalBackend",
     "RemoteBackend",
+    "Session",
+    "SessionManager",
     "load_backend",
     "set_context_menu",
     "context_menu_enabled",
@@ -36,6 +40,48 @@ class RemoteBackend:
 
 
 _context_menu_enabled = False
+
+
+# ---------------------------------------------------------------- Session API
+@dataclass
+class Session:
+    """Represent an interactive session for a specific user and backend."""
+
+    user: str
+    backend: Backend
+    history: List[Tuple[str, str]] = field(default_factory=list)
+
+
+class SessionManager:
+    """Manage multiple user sessions for different backends."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, Session] = {}
+
+    # --------------------------------------------------------------- lifecycle
+    def create(self, user: str, backend: Backend) -> str:
+        """Create a new session and return its id."""
+
+        sid = token_urlsafe(16)
+        self._sessions[sid] = Session(user, backend)
+        return sid
+
+    def end(self, session_id: str) -> None:
+        """Terminate a session if it exists."""
+
+        self._sessions.pop(session_id, None)
+
+    # ----------------------------------------------------------------- helpers
+    def get(self, session_id: str) -> Session:
+        return self._sessions[session_id]
+
+    def send(self, session_id: str, prompt: str) -> str:
+        """Send *prompt* through the session's backend and record the result."""
+
+        session = self.get(session_id)
+        response = session.backend.generate(prompt)
+        session.history.append((prompt, response))
+        return response
 
 
 def set_context_menu(enabled: bool) -> None:

--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -6,6 +6,7 @@ to switch between local models and remote APIs.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Dict, Optional
 
 try:  # pragma: no cover - import may fail on headless systems
@@ -29,7 +30,44 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover
     qrcode = None  # type: ignore[assignment]
 
-__all__ = ["ChatGUI", "main"]
+__all__ = ["ChatGUI", "DashboardManager", "main"]
+
+
+# ---------------------------------------------------------------- Dashboards
+@dataclass
+class Dashboard:
+    name: str
+    owner: str
+    roles: Dict[str, str] = field(default_factory=dict)
+
+
+class DashboardManager:
+    """Manage shared dashboards with simple role-based access control."""
+
+    def __init__(self) -> None:
+        self.dashboards: Dict[str, Dashboard] = {}
+
+    def create(self, name: str, owner: str) -> None:
+        dash = Dashboard(name, owner, {owner: "owner"})
+        self.dashboards[name] = dash
+
+    def share(self, name: str, user: str, role: str) -> None:
+        if name not in self.dashboards:
+            raise KeyError(f"Unknown dashboard {name}")
+        self.dashboards[name].roles[user] = role
+
+    def can_access(self, name: str, user: str, role: str) -> bool:
+        dash = self.dashboards.get(name)
+        if not dash:
+            return False
+        current = dash.roles.get(user)
+        if current == "owner":
+            return True
+        if current == "edit":
+            return role in {"edit", "view"}
+        if current == "view":
+            return role == "view"
+        return False
 
 
 class ChatGUI:
@@ -60,6 +98,7 @@ class ChatGUI:
         # Security
         self.audit_logger = AuditLogger()
         self.permission_manager = PermissionManager(audit_logger=self.audit_logger)
+        self.dashboard_manager = DashboardManager()
 
         self._build_widgets()
 
@@ -151,6 +190,16 @@ class ChatGUI:
         tuning.revert()
         self.chat.insert("end", "[Optimization] Reverted profile\n")
         self.chat.see("end")
+
+    # ---------------------------------------------------------- Dashboards API
+    def create_dashboard(self, name: str, owner: str) -> None:
+        self.dashboard_manager.create(name, owner)
+
+    def share_dashboard(self, name: str, user: str, role: str) -> None:
+        self.dashboard_manager.share(name, user, role)
+
+    def can_access_dashboard(self, name: str, user: str, role: str) -> bool:
+        return self.dashboard_manager.can_access(name, user, role)
 
     # ----------------------------------------------------------------- Chat
     def _open_mesh_config(self) -> None:

--- a/docs/enterprise.md
+++ b/docs/enterprise.md
@@ -1,0 +1,20 @@
+# Enterprise Deployment
+
+The Windows AI Control Center supports enterprise deployments through a set of
+features aimed at teams and regulated environments.
+
+## Multi-User Sessions
+- The backend layer now includes a session manager that isolates user
+  conversations and maintains history per session.
+
+## Shared Dashboards
+- Administrators can create dashboards and share them with team members.
+- Role-based access control limits each user's abilities to **view** or **edit**
+  shared dashboards.
+
+## Compliance Logging
+- Security events and permission changes are logged for auditing.
+- Compliance events can be exported in JSON or CSV for external reporting.
+
+These capabilities enable centralized control while satisfying common
+enterprise requirements.

--- a/security/audit.py
+++ b/security/audit.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict, field
 from datetime import datetime
 from pathlib import Path
+from typing import List
+import csv
+import json
 
 
 @dataclass
@@ -12,6 +15,7 @@ class AuditLogger:
     """Record security related events to a log file."""
 
     path: Path | str | None = None
+    compliance_events: List["ComplianceEvent"] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.path = Path(self.path or Path("audit.log"))
@@ -31,3 +35,48 @@ class AuditLogger:
         if not self.path.exists():
             return ""
         return self.path.read_text(encoding="utf-8")
+
+    # ---------------------------------------------------------- compliance API
+    def log_compliance(self, user: str, action: str, resource: str) -> None:
+        """Record a structured compliance event in memory."""
+
+        event = ComplianceEvent(datetime.utcnow(), user, action, resource)
+        self.compliance_events.append(event)
+
+    def export(self, dest: Path | str, fmt: str = "json") -> None:
+        """Export collected compliance events to *dest* in JSON or CSV format."""
+
+        dest_path = Path(dest)
+        if fmt == "json":
+            data = [
+                {**asdict(e), "timestamp": e.timestamp.isoformat()}
+                for e in self.compliance_events
+            ]
+            dest_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        elif fmt == "csv":
+            with dest_path.open("w", newline="", encoding="utf-8") as fh:
+                writer = csv.DictWriter(
+                    fh, fieldnames=["timestamp", "user", "action", "resource"]
+                )
+                writer.writeheader()
+                for e in self.compliance_events:
+                    writer.writerow(
+                        {
+                            "timestamp": e.timestamp.isoformat(),
+                            "user": e.user,
+                            "action": e.action,
+                            "resource": e.resource,
+                        }
+                    )
+        else:  # pragma: no cover - defensive
+            raise ValueError(f"unknown format: {fmt}")
+
+
+@dataclass
+class ComplianceEvent:
+    """Single compliance log entry."""
+
+    timestamp: datetime
+    user: str
+    action: str
+    resource: str

--- a/tests/test_dashboard_permissions.py
+++ b/tests/test_dashboard_permissions.py
@@ -1,0 +1,14 @@
+from control_center.gui import DashboardManager
+
+
+def test_dashboard_role_access():
+    mgr = DashboardManager()
+    mgr.create("team", "alice")
+    mgr.share("team", "bob", "view")
+
+    # Owner has full access
+    assert mgr.can_access("team", "alice", "edit")
+
+    # Viewer can only view
+    assert mgr.can_access("team", "bob", "view")
+    assert not mgr.can_access("team", "bob", "edit")


### PR DESCRIPTION
## Summary
- add session manager to backends for multi-user conversations
- support shared dashboards with role-based access control in GUI
- implement compliance event logging and export
- document enterprise deployment features
- test dashboard role permissions

## Testing
- `pytest tests/test_dashboard_permissions.py tests/test_security_permissions.py tests/test_control_center_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_688ffb4fff808326a85b12457735be29