### PR TITLE
feat: add eco computing utilities and scheduler

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -24,6 +24,7 @@ from secrets import token_urlsafe
 from plugins.manager import PluginManager
 from security import AuditLogger, PermissionManager
 from optimization import tuning
+from eco.scheduler import EcoScheduler
 
 try:  # pragma: no cover - optional dependency
     import qrcode  # type: ignore
@@ -77,6 +78,7 @@ class ChatGUI:
         self,
         root: Optional["tk.Tk"] = None,
         backends: Optional[Dict[str, Backend]] = None,
+        scheduler: Optional[EcoScheduler] = None,
     ) -> None:
         if tk is None or ttk is None:
             raise RuntimeError("tkinter is not available")
@@ -99,6 +101,7 @@ class ChatGUI:
         self.audit_logger = AuditLogger()
         self.permission_manager = PermissionManager(audit_logger=self.audit_logger)
         self.dashboard_manager = DashboardManager()
+        self.scheduler = scheduler or EcoScheduler()
 
         self._build_widgets()
 
@@ -177,6 +180,12 @@ class ChatGUI:
         ttk.Button(
             input_frame, text="Automation", command=self._open_automation_builder
         ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Defer", command=self.schedule_message
+        ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Scheduler", command=self._open_scheduler_settings
+        ).pack(side="left", padx=5)
 
     def apply_profile(self) -> None:
         """Apply the selected optimization profile."""
@@ -190,6 +199,47 @@ class ChatGUI:
         tuning.revert()
         self.chat.insert("end", "[Optimization] Reverted profile\n")
         self.chat.see("end")
+
+    # ------------------------------------------------------------- Scheduling
+    def schedule_message(self) -> None:
+        """Schedule the current entry text for the next off-peak window."""
+
+        prompt = self.entry.get().strip()
+        if not prompt:
+            return
+        backend = self.backends[self.backend_var.get()]
+
+        def run() -> None:
+            response = backend.generate(prompt)
+            self.chat.insert("end", f"[Off-peak] Bot: {response}\n")
+            self.chat.see("end")
+
+        self.scheduler.schedule(run)
+        self.chat.insert("end", f"[Scheduled] {prompt}\n")
+        self.chat.see("end")
+        self.entry.delete(0, "end")
+
+    def _open_scheduler_settings(self) -> None:
+        """Configure off-peak hours for deferred tasks."""
+
+        win = tk.Toplevel(self.root)
+        win.title("Scheduler")
+        start_var = tk.IntVar(value=self.scheduler.start_hour)
+        end_var = tk.IntVar(value=self.scheduler.end_hour)
+
+        ttk.Label(win, text="Start hour:").grid(row=0, column=0, padx=5, pady=5, sticky="w")
+        ttk.Entry(win, textvariable=start_var, width=5).grid(row=0, column=1, padx=5, pady=5)
+        ttk.Label(win, text="End hour:").grid(row=1, column=0, padx=5, pady=5, sticky="w")
+        ttk.Entry(win, textvariable=end_var, width=5).grid(row=1, column=1, padx=5, pady=5)
+
+        def save() -> None:
+            self.scheduler.start_hour = start_var.get()
+            self.scheduler.end_hour = end_var.get()
+            win.destroy()
+
+        ttk.Button(win, text="Save", command=save).grid(
+            row=2, column=0, columnspan=2, pady=5
+        )
 
     # ---------------------------------------------------------- Dashboards API
     def create_dashboard(self, name: str, owner: str) -> None:

--- a/docs/eco_computing.md
+++ b/docs/eco_computing.md
@@ -1,0 +1,14 @@
+# Eco Computing
+
+The Windows AI platform includes a lightweight :mod:`eco` package that helps
+monitor and reduce energy consumption:
+
+- **Energy tracking** – :class:`eco.tracker.EnergyTracker` reads battery and
+  power information via OS APIs when available.
+- **Off-peak scheduling** – :class:`eco.scheduler.EcoScheduler` can defer heavy
+  compute tasks until configurable off‑peak hours.
+- **Eco reports** – :func:`eco.reports.generate_report` summarizes the current
+  power state and provides practical tips for reducing usage.
+
+The Control Center integrates the scheduler, allowing prompts to be queued for
+execution when the system is in an off‑peak window.

--- a/eco/__init__.py
+++ b/eco/__init__.py
@@ -1,0 +1,13 @@
+"""Eco computing utilities for Windows-AI.
+
+The :mod:`eco` package provides energy tracking, scheduling helpers and
+report generation aimed at reducing power consumption.  The modules are
+light‑weight and rely only on the Python standard library and optional
+``psutil`` hooks when available.
+"""
+
+from .tracker import EnergyTracker
+from .reports import generate_report
+from .scheduler import EcoScheduler
+
+__all__ = ["EnergyTracker", "EcoScheduler", "generate_report"]

--- a/eco/reports.py
+++ b/eco/reports.py
@@ -1,0 +1,36 @@
+"""Simple eco report generation and tips."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .tracker import EnergyTracker
+
+_TIPS = [
+    "Dim your display to reduce power usage.",
+    "Close applications you are not actively using.",
+    "Schedule heavy compute for off‑peak hours.",
+]
+
+
+def eco_tips() -> List[str]:
+    """Return a list of energy saving tips."""
+
+    return list(_TIPS)
+
+
+def generate_report() -> str:
+    """Generate a small human readable eco report."""
+
+    tracker = EnergyTracker()
+    info = tracker.current()
+    lines = ["# Eco Report"]
+    lines.append(f"Battery: {info.percent if info.percent is not None else 'n/a'}%")
+    lines.append(
+        f"Plugged in: {'yes' if info.power_plugged else 'no' if info.power_plugged is not None else 'n/a'}"
+    )
+    lines.append("")
+    lines.append("## Tips")
+    for tip in eco_tips():
+        lines.append(f"- {tip}")
+    return "\n".join(lines)

--- a/eco/scheduler.py
+++ b/eco/scheduler.py
@@ -1,0 +1,50 @@
+"""Utilities for deferring work to off‑peak hours."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, time, timedelta
+from threading import Timer
+from typing import Callable, Optional
+
+
+@dataclass
+class EcoScheduler:
+    """Schedule callables for execution during off‑peak hours.
+
+    Off‑peak hours are defined by a start hour and an end hour.  The window can
+    span midnight (e.g. 22 → 6).  The :meth:`next_run` method computes the next
+    eligible run time and :meth:`schedule` uses :class:`threading.Timer` to
+    execute a callable when the window opens.
+    """
+
+    start_hour: int = 22
+    end_hour: int = 6
+
+    def is_off_peak(self, dt: datetime) -> bool:
+        start = time(self.start_hour, 0)
+        end = time(self.end_hour, 0)
+        if self.start_hour < self.end_hour:
+            return start <= dt.time() < end
+        return dt.time() >= start or dt.time() < end
+
+    def next_run(self, now: Optional[datetime] = None) -> datetime:
+        now = now or datetime.now()
+        if self.is_off_peak(now):
+            return now
+        start_time = time(self.start_hour, 0)
+        run_day = now.date()
+        if now.time() >= start_time:
+            run_day += timedelta(days=1)
+        return datetime.combine(run_day, start_time)
+
+    def schedule(self, func: Callable[[], None], now: Optional[datetime] = None) -> Timer:
+        """Schedule ``func`` to run at the next off‑peak time."""
+
+        now = now or datetime.now()
+        run_at = self.next_run(now)
+        delay = (run_at - now).total_seconds()
+        timer = Timer(delay, func)
+        timer.daemon = True
+        timer.start()
+        return timer

--- a/eco/tracker.py
+++ b/eco/tracker.py
@@ -1,0 +1,47 @@
+"""Energy usage tracking helpers.
+
+The :class:`EnergyTracker` class uses optional ``psutil`` readings to provide
+basic information about the system's power state.  When the dependency is not
+available or the platform lacks support the tracker gracefully falls back to
+returning ``None`` values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+try:  # pragma: no cover - psutil optional
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - psutil optional
+    psutil = None  # type: ignore
+
+
+@dataclass
+class PowerInfo:
+    """Simple container for power readings."""
+
+    percent: Optional[float]
+    secs_left: Optional[int]
+    power_plugged: Optional[bool]
+
+
+class EnergyTracker:
+    """Track energy usage via OS APIs when available."""
+
+    def current(self) -> PowerInfo:
+        """Return current power information.
+
+        The data is sourced from :func:`psutil.sensors_battery` when available.
+        Missing values are represented by ``None``.
+        """
+
+        if not psutil:
+            return PowerInfo(None, None, None)
+        try:
+            batt = psutil.sensors_battery()
+        except Exception:
+            batt = None
+        if not batt:
+            return PowerInfo(None, None, None)
+        return PowerInfo(batt.percent, batt.secsleft, batt.power_plugged)

--- a/tests/test_eco_scheduler.py
+++ b/tests/test_eco_scheduler.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from eco.scheduler import EcoScheduler
+
+
+def test_next_run_in_off_peak():
+    sched = EcoScheduler(start_hour=22, end_hour=6)
+    now = datetime(2024, 1, 1, 23, 0)
+    assert sched.is_off_peak(now)
+    assert sched.next_run(now) == now
+
+
+def test_next_run_before_window():
+    sched = EcoScheduler(start_hour=22, end_hour=6)
+    now = datetime(2024, 1, 1, 20, 0)
+    expected = datetime(2024, 1, 1, 22, 0)
+    assert sched.next_run(now) == expected
+
+
+def test_next_run_after_window():
+    sched = EcoScheduler(start_hour=22, end_hour=6)
+    now = datetime(2024, 1, 1, 7, 0)
+    expected = datetime(2024, 1, 1, 22, 0)
+    assert sched.next_run(now) == expected


### PR DESCRIPTION
## Summary
- add eco package with energy tracking, scheduler, and reporting helpers
- integrate off-peak scheduling controls into Control Center GUI
- document eco computing features and test scheduler logic

## Testing
- `pytest tests/test_control_center_gui.py tests/test_eco_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688fff464f248326ac91545b244860f5