### PR TITLE
feat: extend actions api and generate sdk

### DIFF
--- a/apps/actions-api/src/index.ts
+++ b/apps/actions-api/src/index.ts
@@ -3,6 +3,9 @@ import { executeAction } from './actions';
 import { normalize } from './normalize';
 import { ValidationError } from './errors';
 import { createPairingToken, handleRemoteCommand } from './mobile';
+import { distributeTask } from './mesh';
+import { handleDeviceEvent } from './iot';
+import { searchDocuments } from './search';
 
 export const app = express();
 app.use(express.json());
@@ -52,6 +55,66 @@ app.post('/api/actions/execute', async (req, res) => {
   try {
     const norm = normalize(req.body);
     const result = await executeAction(norm);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack
+        })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/mesh/distribute', (req, res) => {
+  try {
+    const result = distributeTask(req.body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack
+        })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/iot/event', (req, res) => {
+  try {
+    const result = handleDeviceEvent(req.body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack
+        })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/search/query', (req, res) => {
+  try {
+    const result = searchDocuments(req.body);
     res.json({ ok: true, result });
   } catch (err: any) {
     if (err instanceof ValidationError) {

--- a/apps/actions-api/src/iot.ts
+++ b/apps/actions-api/src/iot.ts
@@ -1,0 +1,16 @@
+import { ValidationError } from './errors';
+
+export interface DeviceEventRequest {
+  deviceId: string;
+  event: string;
+}
+
+export function handleDeviceEvent(req: DeviceEventRequest) {
+  const deviceId = req.deviceId?.trim();
+  const event = req.event?.trim();
+  if (!deviceId || !event) {
+    throw new ValidationError('Missing deviceId or event');
+  }
+  // Placeholder implementation
+  return { deviceId, event };
+}

--- a/apps/actions-api/src/mesh.ts
+++ b/apps/actions-api/src/mesh.ts
@@ -1,0 +1,12 @@
+import { ValidationError } from './errors';
+
+export interface MeshTaskRequest {
+  task: string;
+}
+
+export function distributeTask(req: MeshTaskRequest) {
+  const task = req.task?.trim();
+  if (!task) throw new ValidationError('Missing task');
+  // Placeholder implementation until mesh integration is complete
+  return { distributed: task };
+}

--- a/apps/actions-api/src/search.ts
+++ b/apps/actions-api/src/search.ts
@@ -1,0 +1,25 @@
+import { ValidationError } from './errors';
+
+export interface SearchRequest {
+  query: string;
+  documents?: Record<string, string>;
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(text.toLowerCase().split(/\W+/).filter(Boolean));
+}
+
+export function searchDocuments(req: SearchRequest) {
+  const query = req.query?.trim();
+  if (!query) throw new ValidationError('Missing query');
+  const docs = req.documents || {};
+  const qTokens = tokenize(query);
+  const scores: Array<{ id: string; score: number }> = [];
+  for (const [id, text] of Object.entries(docs)) {
+    const docTokens = tokenize(text);
+    const score = [...qTokens].filter((t) => docTokens.has(t)).length;
+    if (score > 0) scores.push({ id, score });
+  }
+  scores.sort((a, b) => b.score - a.score);
+  return scores.map((s) => s.id);
+}

--- a/apps/actions-api/test/iot.test.ts
+++ b/apps/actions-api/test/iot.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { app } from '../src/index';
+
+async function startServer() {
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  const address = server.address();
+  if (typeof address === 'string' || !address) {
+    throw new Error('Failed to get server address');
+  }
+  return { server, port: address.port };
+}
+
+test('iot event handles device event', async () => {
+  const { server, port } = await startServer();
+  const res = await fetch(`http://localhost:${port}/api/iot/event`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ deviceId: 'lamp', event: 'on' })
+  });
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.strictEqual(body.ok, true);
+  assert.strictEqual(body.result.deviceId, 'lamp');
+  await new Promise((resolve) => server.close(resolve));
+});

--- a/apps/actions-api/test/mesh.test.ts
+++ b/apps/actions-api/test/mesh.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { app } from '../src/index';
+
+async function startServer() {
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  const address = server.address();
+  if (typeof address === 'string' || !address) {
+    throw new Error('Failed to get server address');
+  }
+  return { server, port: address.port };
+}
+
+test('mesh distribute echoes task', async () => {
+  const { server, port } = await startServer();
+  const res = await fetch(`http://localhost:${port}/api/mesh/distribute`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ task: 'compute' })
+  });
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.strictEqual(body.ok, true);
+  assert.strictEqual(body.result.distributed, 'compute');
+  await new Promise((resolve) => server.close(resolve));
+});

--- a/apps/actions-api/test/search.test.ts
+++ b/apps/actions-api/test/search.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { app } from '../src/index';
+
+async function startServer() {
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  const address = server.address();
+  if (typeof address === 'string' || !address) {
+    throw new Error('Failed to get server address');
+  }
+  return { server, port: address.port };
+}
+
+test('search query returns matching documents', async () => {
+  const { server, port } = await startServer();
+  const res = await fetch(`http://localhost:${port}/api/search/query`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      query: 'hello world',
+      documents: {
+        a: 'hello there',
+        b: 'general kenobi',
+        c: 'world news'
+      }
+    })
+  });
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.strictEqual(body.ok, true);
+  assert.deepStrictEqual(body.result, ['a', 'c']);
+  await new Promise((resolve) => server.close(resolve));
+});

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,55 @@
+# Windows AI Actions API
+
+This API exposes system functionality such as shell commands, mesh networking, IoT events and search utilities. All endpoints accept and return JSON.
+
+## Endpoints
+
+### `POST /api/actions/execute`
+Execute a named action on the host.
+
+```json
+{
+  "action": "shell",
+  "params": { "command": "echo hi" }
+}
+```
+
+### `POST /api/mobile/pair`
+Create a pairing token for a mobile device.
+
+```json
+{ "deviceId": "phone-1" }
+```
+
+### `POST /api/mobile/command`
+Execute an action on behalf of a paired device.
+
+```json
+{ "token": "<token>", "action": "get_system_info" }
+```
+
+### `POST /api/mesh/distribute`
+Distribute a task to mesh nodes.
+
+```json
+{ "task": "render frame" }
+```
+
+### `POST /api/iot/event`
+Submit an IoT device event.
+
+```json
+{ "deviceId": "lamp", "event": "on" }
+```
+
+### `POST /api/search/query`
+Query a set of documents and return matching ids.
+
+```json
+{
+  "query": "hello world",
+  "documents": { "a": "hello there", "b": "general kenobi" }
+}
+```
+
+Each response contains an `ok` field and a `result` or `token` depending on the endpoint.

--- a/openapi/windows-ai.yaml
+++ b/openapi/windows-ai.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Windows AI Actions API
-  version: 0.1.0
+  version: 0.2.0
 paths:
   /api/actions/execute:
     post:
@@ -19,3 +19,147 @@ paths:
             application/json:
               schema:
                 $ref: ../codex/SCHEMAS/actions.response.schema.json
+  /api/mobile/pair:
+    post:
+      summary: Create a pairing token for a mobile device
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deviceId:
+                  type: string
+              required: [deviceId]
+      responses:
+        "200":
+          description: Pairing token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  token:
+                    type: string
+  /api/mobile/command:
+    post:
+      summary: Execute a command from a paired mobile device
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                action:
+                  type: string
+                params:
+                  type: object
+      responses:
+        "200":
+          description: Action result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  result:
+                    type: object
+  /api/mesh/distribute:
+    post:
+      summary: Distribute a task to mesh nodes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                task:
+                  type: string
+              required: [task]
+      responses:
+        "200":
+          description: Distribution acknowledgement
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  result:
+                    type: object
+                    properties:
+                      distributed:
+                        type: string
+  /api/iot/event:
+    post:
+      summary: Handle an IoT device event
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deviceId:
+                  type: string
+                event:
+                  type: string
+              required: [deviceId, event]
+      responses:
+        "200":
+          description: Event acknowledgement
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  result:
+                    type: object
+                    properties:
+                      deviceId:
+                        type: string
+                      event:
+                        type: string
+  /api/search/query:
+    post:
+      summary: Query a set of documents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                documents:
+                  type: object
+                  additionalProperties:
+                    type: string
+              required: [query]
+      responses:
+        "200":
+          description: Matching document ids
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  result:
+                    type: array
+                    items:
+                      type: string

--- a/sdk/mobile/client.js
+++ b/sdk/mobile/client.js
@@ -1,0 +1,42 @@
+export default class WindowsAIClient {
+  constructor(baseUrl) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  async _post(path, body) {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) {
+      throw new Error(`Request failed: ${res.status}`);
+    }
+    const data = await res.json();
+    return data.result ?? data.token;
+  }
+
+  executeAction(action, params = {}) {
+    return this._post('/api/actions/execute', { action, params });
+  }
+
+  mobilePair(deviceId) {
+    return this._post('/api/mobile/pair', { deviceId });
+  }
+
+  mobileCommand(token, action, params = {}) {
+    return this._post('/api/mobile/command', { token, action, params });
+  }
+
+  meshDistribute(task) {
+    return this._post('/api/mesh/distribute', { task });
+  }
+
+  iotEvent(deviceId, event) {
+    return this._post('/api/iot/event', { deviceId, event });
+  }
+
+  searchQuery(query, documents = {}) {
+    return this._post('/api/search/query', { query, documents });
+  }
+}

--- a/sdk/node/client.js
+++ b/sdk/node/client.js
@@ -1,0 +1,40 @@
+export class WindowsAIClient {
+  constructor(baseUrl) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  async _post(path, body) {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+    const data = await res.json();
+    return data.result ?? data.token;
+  }
+
+  executeAction(action, params = {}) {
+    return this._post('/api/actions/execute', { action, params });
+  }
+
+  mobilePair(deviceId) {
+    return this._post('/api/mobile/pair', { deviceId });
+  }
+
+  mobileCommand(token, action, params = {}) {
+    return this._post('/api/mobile/command', { token, action, params });
+  }
+
+  meshDistribute(task) {
+    return this._post('/api/mesh/distribute', { task });
+  }
+
+  iotEvent(deviceId, event) {
+    return this._post('/api/iot/event', { deviceId, event });
+  }
+
+  searchQuery(query, documents = {}) {
+    return this._post('/api/search/query', { query, documents });
+  }
+}

--- a/sdk/python/windows_ai_client.py
+++ b/sdk/python/windows_ai_client.py
@@ -1,0 +1,44 @@
+import requests
+from typing import Dict, Any, Optional, List
+
+class WindowsAIClient:
+    """Simple client for the Windows AI Actions API."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip('/')
+
+    def execute_action(self, action: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        res = requests.post(f"{self.base_url}/api/actions/execute", json={"action": action, "params": params or {}})
+        res.raise_for_status()
+        return res.json()["result"]
+
+    def mobile_pair(self, device_id: str) -> str:
+        res = requests.post(f"{self.base_url}/api/mobile/pair", json={"deviceId": device_id})
+        res.raise_for_status()
+        return res.json()["token"]
+
+    def mobile_command(self, token: str, action: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        res = requests.post(
+            f"{self.base_url}/api/mobile/command",
+            json={"token": token, "action": action, "params": params or {}}
+        )
+        res.raise_for_status()
+        return res.json()["result"]
+
+    def mesh_distribute(self, task: str) -> Dict[str, Any]:
+        res = requests.post(f"{self.base_url}/api/mesh/distribute", json={"task": task})
+        res.raise_for_status()
+        return res.json()["result"]
+
+    def iot_event(self, device_id: str, event: str) -> Dict[str, Any]:
+        res = requests.post(f"{self.base_url}/api/iot/event", json={"deviceId": device_id, "event": event})
+        res.raise_for_status()
+        return res.json()["result"]
+
+    def search_query(self, query: str, documents: Optional[Dict[str, str]] = None) -> List[str]:
+        res = requests.post(
+            f"{self.base_url}/api/search/query",
+            json={"query": query, "documents": documents or {}}
+        )
+        res.raise_for_status()
+        return res.json()["result"]


### PR DESCRIPTION
## Summary
- expose mesh, IoT, and search endpoints in Actions API
- document and model new endpoints in OpenAPI spec and API reference
- scaffold Python, Node, and mobile SDK clients

## Testing
- `npm --prefix apps/actions-api run build`
- `npm --prefix apps/actions-api test`
- `pytest tests/test_mesh_connection.py`


------
https://chatgpt.com/codex/tasks/task_e_6890016bd0e08326917f462ad3578b40