### PR TITLE
feat: add updater module with rollback support

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -25,6 +25,7 @@ from plugins.manager import PluginManager
 from security import AuditLogger, PermissionManager
 from optimization import tuning
 from eco.scheduler import EcoScheduler
+from updater import Updater
 
 try:  # pragma: no cover - optional dependency
     import qrcode  # type: ignore
@@ -102,6 +103,7 @@ class ChatGUI:
         self.permission_manager = PermissionManager(audit_logger=self.audit_logger)
         self.dashboard_manager = DashboardManager()
         self.scheduler = scheduler or EcoScheduler()
+        self.updater = Updater()
 
         self._build_widgets()
 
@@ -186,6 +188,9 @@ class ChatGUI:
         ttk.Button(
             input_frame, text="Scheduler", command=self._open_scheduler_settings
         ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Updates", command=self._open_update_settings
+        ).pack(side="left", padx=5)
 
     def apply_profile(self) -> None:
         """Apply the selected optimization profile."""
@@ -240,6 +245,27 @@ class ChatGUI:
         ttk.Button(win, text="Save", command=save).grid(
             row=2, column=0, columnspan=2, pady=5
         )
+
+    def _open_update_settings(self) -> None:
+        """Simple update window showing release notes."""
+
+        win = tk.Toplevel(self.root)
+        win.title("Updates")
+        ttk.Button(win, text="Check", command=self._check_updates).pack(
+            padx=5, pady=5
+        )
+        self._release_notes = tk.Text(win, height=10, width=60, state="disabled")
+        self._release_notes.pack(fill="both", expand=True, padx=5, pady=5)
+
+    def _check_updates(self) -> None:
+        version = self.updater.latest_version()
+        notes = self.updater.get_release_notes(version)
+        self._release_notes.config(state="normal")
+        self._release_notes.delete("1.0", "end")
+        self._release_notes.insert(
+            "1.0", f"Latest version: {version}\n\n{notes}".strip()
+        )
+        self._release_notes.config(state="disabled")
 
     # ---------------------------------------------------------- Dashboards API
     def create_dashboard(self, name: str, owner: str) -> None:

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -1,0 +1,18 @@
+# Updater
+
+The `updater` package provides a light‑weight mechanism for keeping the
+Windows AI installation up to date.  Updates follow a three step
+process:
+
+1. **Version check** – `Updater.latest_version()` fetches metadata from
+the update server and compares it with the currently installed version.
+2. **Download and verification** – `Updater.download()` retrieves the
+update package while `Updater.verify_signature()` validates the SHA256
+signature published alongside the release.
+3. **Install with rollback** – `Updater.apply_update()` snapshots the
+existing installation, invokes the PowerShell scripts in the
+`install/` directory and restores the snapshot if the installation
+fails.
+
+The `ChatGUI` exposes these features through *Settings → Updates* where
+release notes for the latest version are displayed.

--- a/tests/test_updater_rollback.py
+++ b/tests/test_updater_rollback.py
@@ -1,0 +1,25 @@
+import pytest
+from updater import Updater
+
+
+def test_rollback_restores_snapshot(tmp_path, monkeypatch):
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    marker = install_dir / "data.txt"
+    marker.write_text("v1")
+
+    updater = Updater(base_url="https://example.com", install_dir=install_dir)
+
+    def fail_install(self, package):
+        raise RuntimeError("install failed")
+
+    def dummy_uninstall(self):
+        pass
+
+    monkeypatch.setattr(Updater, "run_install", fail_install)
+    monkeypatch.setattr(Updater, "run_uninstall", dummy_uninstall)
+
+    with pytest.raises(RuntimeError):
+        updater.apply_update(tmp_path / "pkg.zip")
+
+    assert marker.read_text() == "v1"

--- a/updater/__init__.py
+++ b/updater/__init__.py
@@ -1,0 +1,141 @@
+"""Update management for Windows AI.
+
+This module provides utilities to check for new versions, download
+update packages, verify cryptographic signatures, and apply updates
+with snapshot and rollback support.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import hashlib
+import shutil
+import subprocess
+import tempfile
+from urllib.request import urlopen
+
+__all__ = ["Updater"]
+
+
+class Updater:
+    """Light‑weight update helper.
+
+    Parameters
+    ----------
+    base_url:
+        Base URL where update metadata and packages are hosted.
+    install_dir:
+        Directory where the application is installed.  Snapshots are
+        created from this path before applying updates so that a failed
+        installation can be rolled back.
+    install_script / rollback_script:
+        Paths to the PowerShell scripts in :mod:`install/` that perform
+        installation and rollback operations.  The methods default to the
+        repository's scripts but are easily monkey‑patched during tests.
+    """
+
+    def __init__(
+        self,
+        base_url: str = "https://example.com/updates",
+        install_dir: Path | str | None = None,
+        install_script: Path | str = Path("install/install.ps1"),
+        rollback_script: Path | str = Path("install/uninstall.ps1"),
+        current_version: str = "0.0.0",
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.install_dir = Path(install_dir or Path.cwd())
+        self.install_script = Path(install_script)
+        self.rollback_script = Path(rollback_script)
+        self.current_version = current_version
+
+    # ------------------------------------------------------------------
+    # Version handling
+    def latest_version(self) -> str:
+        """Return the latest available version.
+
+        Network failures simply return the current version so that the
+        GUI can show a sensible default when offline.
+        """
+
+        try:  # pragma: no cover - network access
+            with urlopen(f"{self.base_url}/latest") as fh:
+                return fh.read().decode().strip()
+        except Exception:  # pragma: no cover - offline fallback
+            return self.current_version
+
+    def download(self, version: str, dest: Path | str) -> Path:
+        """Download the update package for *version* to *dest*."""
+
+        dest_path = Path(dest)
+        with urlopen(f"{self.base_url}/{version}/package.zip") as fh:
+            dest_path.write_bytes(fh.read())
+        return dest_path
+
+    def verify_signature(self, file_path: Path | str, version: str) -> bool:
+        """Verify the SHA256 signature of *file_path* for *version*."""
+
+        file_path = Path(file_path)
+        digest = hashlib.sha256(file_path.read_bytes()).hexdigest()
+        try:  # pragma: no cover - network access
+            with urlopen(f"{self.base_url}/{version}/package.sig") as fh:
+                signature = fh.read().decode().strip()
+        except Exception:  # pragma: no cover - offline fallback
+            return False
+        return digest == signature
+
+    def get_release_notes(self, version: str) -> str:
+        """Retrieve release notes for *version*."""
+
+        try:  # pragma: no cover - network access
+            with urlopen(f"{self.base_url}/{version}/notes.txt") as fh:
+                return fh.read().decode()
+        except Exception:  # pragma: no cover - offline fallback
+            return "No release notes available."
+
+    # ------------------------------------------------------------------
+    # Snapshot and rollback
+    def _snapshot_path(self) -> Path:
+        return Path(tempfile.mkdtemp(prefix="waisnap_"))
+
+    def create_snapshot(self) -> Path:
+        """Create a snapshot of the install directory and return it."""
+
+        snap = self._snapshot_path()
+        if self.install_dir.exists():
+            shutil.copytree(self.install_dir, snap / "install", dirs_exist_ok=True)
+        return snap
+
+    def rollback(self, snapshot: Path) -> None:
+        """Restore the install directory from *snapshot*."""
+
+        try:
+            self.run_uninstall()
+        finally:
+            if self.install_dir.exists():
+                shutil.rmtree(self.install_dir)
+            shutil.copytree(snapshot / "install", self.install_dir, dirs_exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Installation helpers
+    def run_install(self, package: Path | str) -> None:
+        """Invoke the PowerShell installer."""
+
+        if not self.install_script.exists():
+            raise FileNotFoundError(self.install_script)
+        subprocess.run(["pwsh", str(self.install_script), str(package)], check=True)
+
+    def run_uninstall(self) -> None:
+        """Invoke the PowerShell rollback script if it exists."""
+
+        if self.rollback_script.exists():
+            subprocess.run(["pwsh", str(self.rollback_script)], check=True)
+
+    def apply_update(self, package: Path | str) -> None:
+        """Apply an update package with automatic rollback on failure."""
+
+        snapshot = self.create_snapshot()
+        try:
+            self.run_install(Path(package))
+        except Exception:
+            self.rollback(snapshot)
+            raise


### PR DESCRIPTION
## Summary
- add `updater` package for version checks, downloads, signature verification, and snapshot-based rollback
- expose update settings in control center GUI with release notes display
- document update workflow and add test for rollback handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900bd59ff08326867c2f8d939f47b7