### PR TITLE
feat: add snapshot rollback support

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -26,6 +26,7 @@ from security import AuditLogger, PermissionManager
 from optimization import tuning
 from eco.scheduler import EcoScheduler
 from updater import Updater
+from installer import snapshot
 
 try:  # pragma: no cover - optional dependency
     import qrcode  # type: ignore
@@ -191,6 +192,24 @@ class ChatGUI:
         ttk.Button(
             input_frame, text="Updates", command=self._open_update_settings
         ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Snapshot", command=self._create_snapshot
+        ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Restore", command=self._restore_snapshot
+        ).pack(side="left", padx=5)
+
+    def _create_snapshot(self) -> None:
+        """Create a system snapshot for later restoration."""
+        snapshot.create_snapshot()
+        self.chat.insert("end", "[Snapshot] Created\n")
+        self.chat.see("end")
+
+    def _restore_snapshot(self) -> None:
+        """Restore the previously recorded snapshot."""
+        snapshot.restore()
+        self.chat.insert("end", "[Snapshot] Restored\n")
+        self.chat.see("end")
 
     def apply_profile(self) -> None:
         """Apply the selected optimization profile."""

--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -1,0 +1,12 @@
+# Rollback and Uninstall
+
+Windows AI records the system changes performed during installation so that they can be undone later.
+
+## Snapshots
+
+Running the installer creates a snapshot file under `~/.windows_ai/` that lists the services and firewall rules added by the setup process.
+Use the Control Center's **Snapshot** button to manually create a snapshot before making further changes and **Restore** to revert the environment.
+
+## Uninstall
+
+The `install/uninstall.ps1` script reads the snapshot and removes any recorded services and firewall rules, returning the machine to its previous state.

--- a/gui/core.py
+++ b/gui/core.py
@@ -205,3 +205,41 @@ class GuiCore:
         """Execute a query and display results in the search overlay."""
 
         if self.search_engine is None:
+            return []
+        results = self.search_engine.search(query)
+        overlay = self.overlays["search"]
+        overlay.content = "\n".join(results)
+        overlay.show()
+        return results
+
+    def register_search_action(self, name: str, action: Callable[[], None]) -> None:
+        """Associate an action callback with a search result."""
+
+        self._search_actions[name] = action
+
+    def activate_search_result(self, name: str) -> bool:
+        """Trigger the callback for *name* if it exists."""
+
+        action = self._search_actions.get(name)
+        if action is None:
+            return False
+        action()
+        return True
+
+    # ---- workflow panels -------------------------------------------------
+
+    def add_workflow_panel(self, tool: str, url: str) -> WorkflowPanel:
+        """Create and register an external workflow panel."""
+
+        panel = WorkflowPanel(tool, url)
+        self.workflow_panels[tool] = panel
+        return panel
+
+    def open_workflow(self, tool: str) -> bool:
+        """Activate a previously registered workflow panel."""
+
+        panel = self.workflow_panels.get(tool)
+        if panel is None:
+            return False
+        panel.open()
+        return True

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,6 +1,15 @@
 Write-Host "Installing Windows AI services..."
+
+# Start a new snapshot so we can rollback these actions later
+if (Get-Command python -ErrorAction SilentlyContinue) {
+    python -m installer.snapshot create
+}
+
 if (Get-Command nssm.exe -ErrorAction SilentlyContinue) {
     nssm install WindowsAIService "node" "apps\server.js"
+    if (Get-Command python -ErrorAction SilentlyContinue) {
+        python -m installer.snapshot record service WindowsAIService
+    }
 }
 if (Get-Command mkcert -ErrorAction SilentlyContinue) {
     mkcert -install
@@ -8,6 +17,9 @@ if (Get-Command mkcert -ErrorAction SilentlyContinue) {
 if (Get-Command New-NetFirewallRule -ErrorAction SilentlyContinue) {
     try {
         New-NetFirewallRule -DisplayName "Windows AI" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 8080 | Out-Null
+        if (Get-Command python -ErrorAction SilentlyContinue) {
+            python -m installer.snapshot record firewall 'Windows AI'
+        }
     } catch {}
 }
 Write-Host "Install complete."

--- a/install/uninstall.ps1
+++ b/install/uninstall.ps1
@@ -1,4 +1,10 @@
 Write-Host "Uninstalling Windows AI services..."
+
+# Use the snapshot to restore system changes
+if (Get-Command python -ErrorAction SilentlyContinue) {
+    python -m installer.snapshot restore
+}
+
 if (Get-Command nssm.exe -ErrorAction SilentlyContinue) {
     nssm remove WindowsAIService confirm
 }

--- a/installer/snapshot.py
+++ b/installer/snapshot.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+"""Simple persistence for system change snapshots.
+
+The installer records system modifications such as created services or
+firewall rules so that they can be undone during uninstallation or rollback.
+This module manages the snapshot file and exposes helpers used by both the
+PowerShell scripts and the GUI.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+import subprocess
+from typing import Set
+
+# Location of the snapshot record
+CONFIG_DIR = Path.home() / ".windows_ai"
+SNAPSHOT_FILE = CONFIG_DIR / "snapshot.json"
+
+
+@dataclass
+class Snapshot:
+    """Representation of recorded system changes."""
+
+    services: Set[str] = field(default_factory=set)
+    firewall_rules: Set[str] = field(default_factory=set)
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> dict[str, list[str]]:
+        return {
+            "services": sorted(self.services),
+            "firewall_rules": sorted(self.firewall_rules),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, list[str]]) -> "Snapshot":
+        return cls(set(data.get("services", [])), set(data.get("firewall_rules", [])))
+
+    def save(self) -> None:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        SNAPSHOT_FILE.write_text(json.dumps(self.to_dict(), indent=2))
+
+    @classmethod
+    def load(cls) -> "Snapshot":
+        if SNAPSHOT_FILE.exists():
+            try:
+                data = json.loads(SNAPSHOT_FILE.read_text())
+                return cls.from_dict(data)
+            except Exception:
+                return cls()
+        return cls()
+
+    def clear(self) -> None:
+        if SNAPSHOT_FILE.exists():
+            SNAPSHOT_FILE.unlink()
+
+
+# ----------------------------------------------------------------------
+# Helper API
+
+def create_snapshot() -> Snapshot:
+    """Create a new empty snapshot on disk and return it."""
+
+    snap = Snapshot()
+    snap.save()
+    return snap
+
+
+def record_service(name: str) -> None:
+    """Record a newly created service."""
+
+    snap = Snapshot.load()
+    snap.services.add(name)
+    snap.save()
+
+
+def record_firewall_rule(name: str) -> None:
+    """Record a firewall rule that should be removed on restore."""
+
+    snap = Snapshot.load()
+    snap.firewall_rules.add(name)
+    snap.save()
+
+
+def restore(snapshot: Snapshot | None = None) -> None:
+    """Restore system changes recorded in *snapshot*.
+
+    Each recorded service is removed using ``nssm`` and each firewall rule is
+    removed via PowerShell's ``Remove-NetFirewallRule`` cmdlet.  Missing
+    commands are ignored and failures do not raise errors so that restore can
+    best-effort undo changes during uninstallation.
+    """
+
+    snap = snapshot or Snapshot.load()
+    for service in snap.services:
+        subprocess.run(["nssm", "remove", service, "confirm"], check=False)
+    for rule in snap.firewall_rules:
+        cmd = f"Remove-NetFirewallRule -DisplayName '{rule}'"
+        subprocess.run(["pwsh", "-NoProfile", "-Command", cmd], check=False)
+    snap.clear()
+
+
+def load_snapshot() -> Snapshot:
+    """Return the current snapshot without modifying it."""
+
+    return Snapshot.load()
+
+
+__all__ = [
+    "Snapshot",
+    "SNAPSHOT_FILE",
+    "create_snapshot",
+    "record_service",
+    "record_firewall_rule",
+    "restore",
+    "load_snapshot",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Manage Windows AI snapshots")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("create")
+
+    rec = sub.add_parser("record")
+    rec.add_argument("kind", choices=["service", "firewall"])
+    rec.add_argument("name")
+
+    sub.add_parser("restore")
+
+    ns = parser.parse_args()
+    if ns.cmd == "create":
+        create_snapshot()
+    elif ns.cmd == "record":
+        if ns.kind == "service":
+            record_service(ns.name)
+        else:
+            record_firewall_rule(ns.name)
+    else:
+        restore()

--- a/tests/test_control_center_gui.py
+++ b/tests/test_control_center_gui.py
@@ -1,4 +1,5 @@
 import builtins
+import builtins
 import importlib
 import sys
 
@@ -38,3 +39,24 @@ def test_gui_launches_with_tkinter():
         gui.ChatGUI(root=root)
     finally:
         root.destroy()
+
+
+def test_snapshot_buttons_invoke_snapshot(monkeypatch):
+    gui = importlib.import_module("control_center.gui")
+    if gui.tk is None:
+        pytest.skip("tkinter not available")
+    try:
+        root = gui.tk.Tk()
+    except gui.tk.TclError:
+        pytest.skip("tkinter cannot open display")
+    root.withdraw()
+    called = {"create": 0, "restore": 0}
+    monkeypatch.setattr(gui.snapshot, "create_snapshot", lambda: called.__setitem__("create", 1))
+    monkeypatch.setattr(gui.snapshot, "restore", lambda: called.__setitem__("restore", 1))
+    try:
+        app = gui.ChatGUI(root=root)
+        app._create_snapshot()
+        app._restore_snapshot()
+    finally:
+        root.destroy()
+    assert called == {"create": 1, "restore": 1}

--- a/tests/test_snapshot_lifecycle.py
+++ b/tests/test_snapshot_lifecycle.py
@@ -1,0 +1,32 @@
+import json
+import subprocess
+
+from installer import snapshot
+
+
+def test_snapshot_record_and_restore(tmp_path, monkeypatch):
+    # Redirect snapshot location to temporary directory
+    monkeypatch.setattr(snapshot, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(snapshot, "SNAPSHOT_FILE", tmp_path / "snapshot.json")
+
+    snapshot.create_snapshot()
+    assert snapshot.SNAPSHOT_FILE.exists()
+    data = json.loads(snapshot.SNAPSHOT_FILE.read_text())
+    assert data == {"services": [], "firewall_rules": []}
+
+    snapshot.record_service("svc")
+    snapshot.record_firewall_rule("rule")
+    data = json.loads(snapshot.SNAPSHOT_FILE.read_text())
+    assert data["services"] == ["svc"]
+    assert data["firewall_rules"] == ["rule"]
+
+    calls = []
+
+    def fake_run(cmd, check=False):  # noqa: D401 - simple spy
+        calls.append(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    snapshot.restore()
+    assert calls[0] == ["nssm", "remove", "svc", "confirm"]
+    assert "Remove-NetFirewallRule" in calls[1][-1]
+    assert not snapshot.SNAPSHOT_FILE.exists()


### PR DESCRIPTION
## Summary
- record install-time system changes and allow restoration during uninstall
- expose snapshot create/restore in Control Center GUI
- document rollback workflow and cover snapshot lifecycle in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68901a4af86883269c8fb27715a73778