### PR TITLE
Use absolute imports for installer scripts

### DIFF
--- a/installer/api_keys.py
+++ b/installer/api_keys.py
@@ -20,7 +20,7 @@ import os
 from getpass import getpass
 from typing import Dict, Optional
 
-from .logging_config import get_logger
+from installer.logging_config import get_logger
 
 logger = get_logger(__name__)
 

--- a/installer/cli.py
+++ b/installer/cli.py
@@ -7,9 +7,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import sys
 
-from . import system_info, api_keys, plugins, env
-from .logging_config import get_logger
+if __package__ is None or __package__ == "":  # pragma: no cover - script entry
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from installer import api_keys, env, plugins, system_info
+from installer.logging_config import get_logger
 
 
 logger = get_logger(__name__)

--- a/installer/env_setup.py
+++ b/installer/env_setup.py
@@ -15,7 +15,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 from packaging.specifiers import SpecifierSet
 
-from . import env, plugins
+from installer import env, plugins
 
 
 def _parse_requirements(requirements: Iterable[str]) -> Dict[str, List[Requirement]]:

--- a/installer/gui.py
+++ b/installer/gui.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import os
+import sys
 import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox, simpledialog, ttk
 
-from . import api_keys, env, model_selector, models, plugins, system_info
-from .assistant import Assistant, ToolTip
+if __package__ is None or __package__ == "":  # pragma: no cover - script entry
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from installer import api_keys, env, model_selector, models, plugins, system_info
+from installer.assistant import Assistant, ToolTip
 
 
 class InstallerGUI:

--- a/installer/gui_installer.py
+++ b/installer/gui_installer.py
@@ -7,11 +7,16 @@ it can run in constrained environments.
 
 from __future__ import annotations
 
+import os
+import sys
 import threading
 import tkinter as tk
 from tkinter import messagebox, simpledialog, ttk
 
-from . import api_keys, model_selector, system_info
+if __package__ is None or __package__ == "":  # pragma: no cover - script entry
+    sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from installer import api_keys, model_selector, system_info
 
 __all__ = ["GUIInstaller", "main"]
 
@@ -140,7 +145,7 @@ class GUIInstaller:
         threading.Thread(target=self._install_worker, daemon=True).start()
 
     def _install_worker(self) -> None:
-        from . import env_setup
+        from installer import env_setup
 
         env_setup.setup_all()
 

--- a/installer/model_selector.py
+++ b/installer/model_selector.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from . import system_info
+from installer import system_info
 
 
 def select_backend(task: str, specs: Dict[str, Any]) -> str:

--- a/installer/plugins/__init__.py
+++ b/installer/plugins/__init__.py
@@ -1,7 +1,7 @@
 """Plugin management package for the Windows AI installer."""
 
-from .manager import Plugin, PluginManager, load_catalog
-from .registry import PluginRegistry, discover_plugins
+from installer.plugins.manager import Plugin, PluginManager, load_catalog
+from installer.plugins.registry import PluginRegistry, discover_plugins
 
 __all__ = [
     "Plugin",


### PR DESCRIPTION
## Summary
- switch installer scripts to absolute imports so they can run when invoked directly
- add `sys.path` adjustment to CLI and GUI entry points for standalone execution

## Testing
- `pytest`
- `python installer/cli.py --help`
- `python installer/gui_installer.py` *(fails: `tkinter is not available or no display is found`)*


------
https://chatgpt.com/codex/tasks/task_e_688fd58da5ac8326b1485351c65bf76b