### PR TITLE
feat(iot): add Zeroconf adapter

### DIFF
--- a/iot/__init__.py
+++ b/iot/__init__.py
@@ -7,6 +7,7 @@ from .mqtt import MQTTAdapter
 from .matter import MatterAdapter
 from .zigbee import ZigbeeAdapter
 from .home_assistant import HomeAssistantAdapter
+from .adapters import ZeroconfAdapter
 from .automation import WorkflowAutomation
 
 ADAPTERS: Dict[str, DeviceAdapter] = {
@@ -14,6 +15,7 @@ ADAPTERS: Dict[str, DeviceAdapter] = {
     "matter": MatterAdapter(),
     "zigbee": ZigbeeAdapter(),
     "home_assistant": HomeAssistantAdapter(),
+    "zeroconf": ZeroconfAdapter(),
 }
 
 
@@ -36,6 +38,7 @@ __all__ = [
     "MatterAdapter",
     "ZigbeeAdapter",
     "HomeAssistantAdapter",
+    "ZeroconfAdapter",
     "discover_devices",
     "pair_device",
     "WorkflowAutomation",

--- a/iot/adapters/__init__.py
+++ b/iot/adapters/__init__.py
@@ -1,0 +1,3 @@
+from .zeroconf import ZeroconfAdapter
+
+__all__ = ["ZeroconfAdapter"]

--- a/iot/adapters/zeroconf.py
+++ b/iot/adapters/zeroconf.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import List
+
+from ..models import Device, DeviceAdapter
+
+
+class ZeroconfAdapter(DeviceAdapter):
+    """Adapter for Zeroconf/mDNS discovered devices."""
+
+    protocol = "zeroconf"
+    service_type = "_http._tcp.local."
+
+    def discover(self) -> List[Device]:
+        from zeroconf import Zeroconf, ServiceBrowser
+
+        devices: List[Device] = []
+        protocol = self.protocol
+
+        class Listener:
+            def add_service(self, zeroconf, type_: str, name: str) -> None:
+                info = zeroconf.get_service_info(type_, name)
+                if not info:
+                    return
+                dev_id = info.properties.get(b"id", info.name.encode()).decode()
+                dev_name = info.name.split(".")[0]
+                devices.append(Device(id=dev_id, name=dev_name, protocol=protocol))
+
+            def update_service(self, zeroconf, type_: str, name: str) -> None:  # pragma: no cover - unused
+                pass
+
+            def remove_service(self, zeroconf, type_: str, name: str) -> None:  # pragma: no cover - unused
+                pass
+
+        zc = Zeroconf()
+        try:
+            ServiceBrowser(zc, self.service_type, Listener())
+        finally:
+            zc.close()
+        return devices
+
+    def pair(self, device: Device) -> bool:
+        return device.protocol == self.protocol

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ uvicorn[standard]>=0.30,<0.32
 litellm>=1.74.0,<1.75.0
 PyYAML>=6.0,<7.0
 markdown>=3.6,<4
+zeroconf>=0.147,<0.148

--- a/tests/test_iot_discovery.py
+++ b/tests/test_iot_discovery.py
@@ -1,9 +1,31 @@
 import pytest
 
-from iot import ADAPTERS, discover_devices
+from iot import ADAPTERS, Device, discover_devices, pair_device
 
 
-def test_discover_devices_returns_devices():
+def _mock_zeroconf(monkeypatch):
+    import zeroconf
+
+    class FakeInfo:
+        name = "ZCDevice._http._tcp.local."
+        properties = {b"id": b"zc-1"}
+
+    class FakeZeroconf:
+        def get_service_info(self, type_, name):
+            return FakeInfo()
+
+        def close(self):
+            pass
+
+    def fake_service_browser(zc, stype, listener):
+        listener.add_service(zc, stype, FakeInfo().name)
+
+    monkeypatch.setattr(zeroconf, "Zeroconf", lambda: FakeZeroconf())
+    monkeypatch.setattr(zeroconf, "ServiceBrowser", fake_service_browser)
+
+
+def test_discover_devices_returns_devices(monkeypatch):
+    _mock_zeroconf(monkeypatch)
     for proto in ADAPTERS:
         devices = discover_devices(proto)
         assert devices, f"no devices for {proto}"
@@ -14,3 +36,13 @@ def test_discover_devices_returns_devices():
 def test_discover_invalid_protocol():
     with pytest.raises(KeyError):
         discover_devices("invalid")
+
+
+def test_zeroconf_pairing(monkeypatch):
+    _mock_zeroconf(monkeypatch)
+    devices = discover_devices("zeroconf")
+    device = devices[0]
+    assert pair_device("zeroconf", device) is True
+
+    wrong = Device(id="x", name="x", protocol="other")
+    assert pair_device("zeroconf", wrong) is False


### PR DESCRIPTION
## Summary
- add ZeroconfAdapter for mDNS discovery and pairing
- expose adapter in iot package and requirements
- test discovery and pairing with simulated Zeroconf services

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_iot_discovery.py`


------
https://chatgpt.com/codex/tasks/task_e_68918fa204e88326943e3549b10b44ec