### PR TITLE
Enhance cleanup suggestions

### DIFF
--- a/tests/test_explorer_ai.py
+++ b/tests/test_explorer_ai.py
@@ -6,9 +6,29 @@ class DummyModel:
         return f"RESULT:{prompt}"
 
 
-def test_suggest_cleanup_records_prompt():
+def test_suggest_cleanup_records_prompt_and_actions(tmp_path):
     model = DummyModel()
     explorer = ExplorerAI(model)
-    result = explorer.suggest_cleanup(["a.txt", "b.txt"])
-    assert result == "RESULT:cleanup: a.txt, b.txt"
-    assert explorer.get_logs() == ["cleanup: a.txt, b.txt"]
+
+    small = tmp_path / "a.txt"
+    small.write_text("hi")
+    log_file = tmp_path / "b.log"
+    log_file.write_text("log")
+    large = tmp_path / "c.bin"
+    large.write_bytes(b"0" * (1_000_001))
+
+    result = explorer.suggest_cleanup([str(small), str(log_file), str(large)])
+
+    prompt = (
+        f"cleanup: {small} ({small.stat().st_size} bytes, .txt), "
+        f"{log_file} ({log_file.stat().st_size} bytes, .log), "
+        f"{large} ({large.stat().st_size} bytes, .bin)"
+    )
+
+    assert result["suggestion"] == f"RESULT:{prompt}"
+    assert explorer.get_logs() == [prompt]
+    assert result["actions"] == {
+        str(small): "none",
+        str(log_file): "delete",
+        str(large): "compress",
+    }

--- a/windows_ai/explorer.py
+++ b/windows_ai/explorer.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, Any
+import os
+from typing import Any, Dict, List
 
 
 class ExplorerAI:
@@ -17,18 +18,41 @@ class ExplorerAI:
         self.model = model
         self._logs: List[str] = []
 
-    def suggest_cleanup(self, files: List[str]) -> str:
+    def suggest_cleanup(self, files: List[str]) -> Dict[str, Any]:
         """Return model suggestions for cleaning up *files*.
+
+        The function inspects file sizes and extensions to build a richer
+        prompt and returns a summary of recommended actions for each file.
 
         Parameters
         ----------
         files:
             A list of file names that might require clean up.
+
+        Returns
+        -------
+        Dict[str, Any]
+            ``{"suggestion": str, "actions": Dict[str, str]}``
         """
 
-        prompt = "cleanup: " + ", ".join(files)
+        details: List[str] = []
+        actions: Dict[str, str] = {}
+        for path in files:
+            size = os.path.getsize(path) if os.path.exists(path) else 0
+            ext = os.path.splitext(path)[1].lower()
+            if ext in {".tmp", ".log"}:
+                action = "delete"
+            elif size > 1_000_000:
+                action = "compress"
+            else:
+                action = "none"
+            actions[path] = action
+            details.append(f"{path} ({size} bytes, {ext or 'no ext'})")
+
+        prompt = "cleanup: " + ", ".join(details)
         self._logs.append(prompt)
-        return self.model.generate(prompt)
+        suggestion = self.model.generate(prompt)
+        return {"suggestion": suggestion, "actions": actions}
 
     def get_logs(self) -> List[str]:
         """Return recorded prompts."""


### PR DESCRIPTION
## Summary
- inspect file sizes and extensions when building cleanup prompts
- return model suggestion alongside per-file actions like delete or compress
- test enriched cleanup recommendations and action summaries

## Testing
- `pytest tests/test_explorer_ai.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68918fa4cb94832693a44fd48ab958c0