### PR TITLE
Add SimpleModel and default GuiCore integration

### DIFF
--- a/gui/core.py
+++ b/gui/core.py
@@ -98,7 +98,21 @@ class HotkeyManager:
 class GuiCore:
     """Minimal GUI core placeholder with overlays and hotkeys."""
 
-    def __init__(self, model: Model):
+    def __init__(self, model: Optional[Model] = None):
+        """Initialize the GUI core.
+
+        If no model is provided a :class:`~gui.simple_model.SimpleModel`
+        instance is created. This keeps the core usable out of the box
+        while still allowing custom models to be injected for tests or
+        other purposes.
+        """
+
+        if model is None:
+            # Import locally to avoid circular imports during type checking.
+            from .simple_model import SimpleModel
+
+            model = SimpleModel()
+
         self.model = model
         self.launched = False
         self._logs: List[str] = []

--- a/gui/simple_model.py
+++ b/gui/simple_model.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+class SimpleModel:
+    """A minimal concrete model used for testing and default behavior."""
+
+    def generate(self, prompt: str) -> str:
+        """Return a deterministic response for a given prompt."""
+        return f"Echo: {prompt}"

--- a/tests/test_gui_simple_model.py
+++ b/tests/test_gui_simple_model.py
@@ -1,0 +1,9 @@
+from gui.core import GuiCore
+from gui.simple_model import SimpleModel
+
+
+def test_chat_returns_simple_model_output():
+    gui = GuiCore()
+    prompt = "hello"
+    expected = SimpleModel().generate(prompt)
+    assert gui.chat(prompt) == expected


### PR DESCRIPTION
## Summary
- add a simple echoing model implementation
- default `GuiCore` to use `SimpleModel` when no model is provided
- test `GuiCore.chat` returns `SimpleModel` output

## Testing
- `pytest tests/test_gui_core.py tests/test_gui_simple_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68918f9b8928832681ce4ba3f8a67738