### PR TITLE
Run tests across npm workspaces in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
   workflow_dispatch:
 
-jobs: 
-  test: 
+jobs:
+  test:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: '3.x'
       - name: Install dependencies
         run: |
@@ -20,3 +20,15 @@ jobs:
           pip install pytest
       - name: Run tests
         run: pytest
+
+  workspace-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Run workspace tests
+        run: npm test

--- a/apps/actions-api/package.json
+++ b/apps/actions-api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/src/index.js",
-    "test": "node --test dist/test/*.test.js"
+    "test": "npm run build && node --test dist/test/*.test.js"
   },
   "dependencies": {
     "express": "^5.1.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   ],
   "scripts": {
     "build": "echo \"(optional) build all workspaces\"",
-    "test": "npm test -w apps/actions-api"
+    "test": "npm test -ws"
   }
 }


### PR DESCRIPTION
## Summary
- run `npm test -ws` from the repo root to cover all workspaces
- build and test the actions-api workspace
- add CI job executing workspace tests via `npm test`

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68918fadd4408326bf65c0a31b201339