### PR TITLE
feat: add permission persistence

### DIFF
--- a/security/permissions.py
+++ b/security/permissions.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
+import json
 from typing import Dict, Set
 
 from .audit import AuditLogger
@@ -14,6 +16,12 @@ class PermissionManager:
 
     permissions: Dict[str, Set[str]] = field(default_factory=dict)
     audit_logger: AuditLogger | None = None
+    path: str | Path | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial
+        if self.path:
+            self.path = Path(self.path)
+            self.load(self.path)
 
     # --------------------------------------------------------------- management
     def grant(self, plugin: str, permission: str) -> None:
@@ -40,3 +48,23 @@ class PermissionManager:
             raise PermissionError(f"{plugin} lacks {permission} permission")
         if self.audit_logger:
             self.audit_logger.log(plugin, "ALLOW", permission)
+
+    # ------------------------------------------------------------ persistence
+    def save(self, path: str | Path | None = None) -> None:
+        target_input = path or self.path
+        if not target_input:
+            raise ValueError("No path provided for saving permissions")
+        target = Path(target_input)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        data = {plugin: sorted(perms) for plugin, perms in self.permissions.items()}
+        target.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    def load(self, path: str | Path | None = None) -> None:
+        target_input = path or self.path
+        if not target_input:
+            return
+        target = Path(target_input)
+        if not target.exists():
+            return
+        data = json.loads(target.read_text(encoding="utf-8"))
+        self.permissions = {plugin: set(perms) for plugin, perms in data.items()}

--- a/tests/test_permission_persistence.py
+++ b/tests/test_permission_persistence.py
@@ -1,0 +1,12 @@
+from security import PermissionManager
+
+
+def test_permission_persistence(tmp_path):
+    perm_file = tmp_path / "perms.json"
+    manager = PermissionManager(path=perm_file)
+    manager.grant("PluginA", "network")
+    manager.save()
+
+    # Simulate a process restart
+    new_manager = PermissionManager(path=perm_file)
+    assert new_manager.has("PluginA", "network")


### PR DESCRIPTION
## Summary
- add JSON persistence for PermissionManager
- optionally load permissions from a file during initialization
- test permissions survive process restarts

## Testing
- `pytest tests/test_permission_persistence.py tests/test_security_permissions.py`


------
https://chatgpt.com/codex/tasks/task_e_68919275fd1483269f4648d9f67ab401