### PR TITLE
feat: add plugin uninstall support

### DIFF
--- a/plugins/manager.py
+++ b/plugins/manager.py
@@ -171,6 +171,68 @@ class PluginManager:
             else:
                 raise
 
+    # ------------------------------------------------------------- uninstallation
+    def uninstall(
+        self,
+        plugin: Plugin,
+        messagebox=None,
+        _stack: set[str] | None = None,
+    ) -> None:
+        """Uninstall a plugin and any unneeded dependencies."""
+
+        if plugin.name not in self._installed:
+            return
+
+        if _stack is None:
+            _stack = set()
+        if plugin.name in _stack:
+            raise ValueError("Cyclic dependency detected")
+        _stack.add(plugin.name)
+
+        # Remove dependencies first when no other installed plugin requires them
+        for dep_name in plugin.dependencies:
+            dep = self.get_plugin(dep_name)
+            if dep is None:
+                raise ValueError(f"Missing dependency: {dep_name}")
+
+            # Determine if another plugin still depends on this dependency
+            shared = any(
+                dep_name in (self.get_plugin(other).dependencies if self.get_plugin(other) else [])
+                for other in self._installed
+                if other != plugin.name
+            )
+            if not shared:
+                self.uninstall(dep, messagebox, _stack)
+
+        _stack.remove(plugin.name)
+
+        try:
+            raw_args = shlex.split(plugin.command, posix=os.name != "nt")
+            if not raw_args:
+                raise ValueError("Empty command")
+
+            if os.name == "nt":
+                exe = raw_args[0]
+                i = 1
+                while i < len(raw_args) and Path(exe).suffix == "":
+                    exe += f" {raw_args[i]}"
+                    i += 1
+                args = [exe, *raw_args[i:]]
+            else:
+                args = raw_args
+
+            if args[0] in self.ALLOWED_COMMANDS and len(args) > 1:
+                args[1] = "uninstall"
+                if args[0] == "pip" and "-y" not in args and "--yes" not in args:
+                    args.append("-y")
+            self.sandbox_run(args)
+            self._installed.discard(plugin.name)
+        except Exception as exc:  # pragma: no cover - subprocess path
+            if messagebox is not None:
+                messagebox.showerror("Plugin Uninstall", f"Failed to uninstall {plugin.name}: {exc}")
+            else:
+                raise
+
 
 __all__ = ["Plugin", "PluginManager", "load_catalog", "SANDBOX_DIR"]
 

--- a/tests/test_plugin_uninstall.py
+++ b/tests/test_plugin_uninstall.py
@@ -1,0 +1,65 @@
+import hashlib
+import subprocess
+
+from plugins.manager import Plugin, PluginManager
+
+
+def make_plugin(name: str, *, deps=None):
+    deps = deps or []
+    return Plugin(
+        name=name,
+        description="",
+        command=f"pip install {name.lower()}",
+        dependencies=deps,
+        signature=hashlib.sha256(name.encode()).hexdigest(),
+    )
+
+
+def test_uninstall_removes_plugin_and_dependencies(monkeypatch):
+    dep = make_plugin("Dep")
+    main = make_plugin("Main", deps=["Dep"])
+    manager = PluginManager()
+    manager.plugins = [dep, main]
+
+    # Install plugins without executing real commands
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    manager.install(main)
+    assert manager._installed == {"Dep", "Main"}
+
+    calls = []
+
+    def fake_run(args, shell, check, cwd, env):
+        calls.append(args)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    manager.uninstall(main)
+
+    assert calls == [
+        ["pip", "uninstall", "dep", "-y"],
+        ["pip", "uninstall", "main", "-y"],
+    ]
+    assert manager._installed == set()
+
+
+def test_uninstall_keeps_shared_dependency(monkeypatch):
+    dep = make_plugin("Dep")
+    main1 = make_plugin("Main1", deps=["Dep"])
+    main2 = make_plugin("Main2", deps=["Dep"])
+    manager = PluginManager()
+    manager.plugins = [dep, main1, main2]
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: None)
+    manager.install(main1)
+    manager.install(main2)
+    assert manager._installed == {"Dep", "Main1", "Main2"}
+
+    calls = []
+
+    def fake_run(args, shell, check, cwd, env):
+        calls.append(args)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    manager.uninstall(main1)
+
+    assert calls == [["pip", "uninstall", "main1", "-y"]]
+    assert manager._installed == {"Dep", "Main2"}


### PR DESCRIPTION
## Summary
- add ability to uninstall plugins and clean up unused dependencies
- cover uninstall behaviour and dependency handling with unit tests

## Testing
- `pytest tests/test_plugin_manager.py tests/test_plugin_uninstall.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891926804d883268c777db08da7ba6f