### PR TITLE
Add unregister methods to XR InputManager

### DIFF
--- a/tests/test_xr_input_manager.py
+++ b/tests/test_xr_input_manager.py
@@ -22,3 +22,28 @@ def test_gesture_and_voice_mapping():
     assert mgr.handle_gesture("unknown") is False
     assert mgr.handle_voice_command("nope") is False
     assert called == ["swipe", "hello"]
+
+
+def test_unregister_callbacks():
+    called = []
+
+    def on_swipe():
+        called.append("swipe")
+
+    def on_hello():
+        called.append("hello")
+
+    mgr = InputManager()
+    mgr.register_gesture("swipe_left", on_swipe)
+    mgr.register_voice_command("hello", on_hello)
+
+    mgr.handle_gesture("swipe_left")
+    mgr.handle_voice_command("hello")
+    assert called == ["swipe", "hello"]
+
+    mgr.unregister_gesture("swipe_left")
+    mgr.unregister_voice_command("hello")
+
+    assert mgr.handle_gesture("swipe_left") is False
+    assert mgr.handle_voice_command("hello") is False
+    assert called == ["swipe", "hello"]

--- a/xr/input_manager.py
+++ b/xr/input_manager.py
@@ -24,10 +24,20 @@ class InputManager:
 
         self._gestures[name] = callback
 
+    def unregister_gesture(self, name: str) -> None:
+        """Remove any gesture callback associated with ``name``."""
+
+        self._gestures.pop(name, None)
+
     def register_voice_command(self, phrase: str, callback: Callback) -> None:
         """Associate ``phrase`` with ``callback`` for voice events."""
 
         self._voice[phrase.lower()] = callback
+
+    def unregister_voice_command(self, phrase: str) -> None:
+        """Remove any voice callback associated with ``phrase``."""
+
+        self._voice.pop(phrase.lower(), None)
 
     def handle_gesture(self, name: str) -> bool:
         """Invoke the callback mapped to ``name`` if present."""


### PR DESCRIPTION
## Summary
- add ability to unregister gesture and voice callbacks in XR InputManager
- test registering and unregistering of callbacks

## Testing
- `pytest tests/test_xr_input_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6891927a634c83268d8d74c58c0b86e0