### PR TITLE
Implement heartbeat and reconnection for mesh nodes

### DIFF
--- a/mesh/hub.py
+++ b/mesh/hub.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import socket
 import threading
-from typing import List
+import time
+from typing import Dict
 
 from .protocol import SecureProtocol
 
@@ -25,9 +26,10 @@ class MeshHub:
         self.port = port
         self.discovery_port = discovery_port
         self.protocol = SecureProtocol(key)
-        self._nodes: List[socket.socket] = []
+        self._nodes: Dict[socket.socket, float] = {}
         self._running = False
         self._lock = threading.Lock()
+        self._timeout = 3.0
 
     # --------------------------------------------------------------- lifecycle
     def start(self) -> None:
@@ -56,6 +58,11 @@ class MeshHub:
         )
         self._server_thread.start()
 
+        self._prune_thread = threading.Thread(
+            target=self._prune_loop, daemon=True
+        )
+        self._prune_thread.start()
+
     def stop(self) -> None:
         self._running = False
         try:
@@ -67,7 +74,7 @@ class MeshHub:
         except Exception:
             pass
         with self._lock:
-            for node in self._nodes:
+            for node in list(self._nodes):
                 try:
                     node.close()
                 except Exception:
@@ -93,7 +100,10 @@ class MeshHub:
             except OSError:
                 break
             with self._lock:
-                self._nodes.append(conn)
+                self._nodes[conn] = time.time()
+            threading.Thread(
+                target=self._node_listener, args=(conn,), daemon=True
+            ).start()
 
     # ---------------------------------------------------------- task handling
     def distribute_task(self, task: str) -> None:
@@ -106,5 +116,51 @@ class MeshHub:
                 try:
                     conn.sendall(packet)
                 except OSError:
-                    self._nodes.remove(conn)
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
+                    del self._nodes[conn]
+
+    # ----------------------------------------------------------- heartbeat
+    def _node_listener(self, conn: socket.socket) -> None:
+        while self._running:
+            try:
+                header = conn.recv(4)
+                if not header:
+                    break
+                length = int.from_bytes(header, "big")
+                data = b""
+                while len(data) < length:
+                    chunk = conn.recv(length - len(data))
+                    if not chunk:
+                        break
+                    data += chunk
+                if len(data) != length:
+                    break
+                if self.protocol.decrypt(data) == b"HB":
+                    with self._lock:
+                        if conn in self._nodes:
+                            self._nodes[conn] = time.time()
+            except OSError:
+                break
+        with self._lock:
+            self._nodes.pop(conn, None)
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    def _prune_loop(self) -> None:
+        while self._running:
+            time.sleep(1)
+            now = time.time()
+            with self._lock:
+                for conn, ts in list(self._nodes.items()):
+                    if now - ts > self._timeout:
+                        try:
+                            conn.close()
+                        except Exception:
+                            pass
+                        del self._nodes[conn]
 

--- a/mesh/node.py
+++ b/mesh/node.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import socket
 import threading
+import time
 from typing import Callable, Tuple
 
 from .protocol import SecureProtocol
@@ -18,11 +19,15 @@ class MeshNode:
         self,
         handle_task: Callable[[str], None],
         key: bytes | None = None,
+        heartbeat_interval: float = 1.0,
     ) -> None:
         self.handle_task = handle_task
         self.protocol = SecureProtocol(key)
+        self.heartbeat_interval = heartbeat_interval
         self._sock: socket.socket | None = None
         self._thread: threading.Thread | None = None
+        self._heartbeat_thread: threading.Thread | None = None
+        self._addr: Tuple[str, int] | None = None
         self._running = False
 
     # ---------------------------------------------------------- discovery
@@ -43,32 +48,52 @@ class MeshNode:
     def connect(self, addr: Tuple[str, int]) -> None:
         """Connect to the hub at *addr*."""
 
+        self._addr = addr
         self._sock = socket.create_connection(addr)
         self._running = True
         self._thread = threading.Thread(target=self._listen, daemon=True)
         self._thread.start()
+        self._heartbeat_thread = threading.Thread(
+            target=self._heartbeat, daemon=True
+        )
+        self._heartbeat_thread.start()
 
     def _listen(self) -> None:
-        assert self._sock is not None
-        sock = self._sock
         while self._running:
+            sock = self._sock
+            if sock is None:
+                if not self._addr:
+                    break
+                try:
+                    self._sock = socket.create_connection(self._addr)
+                    continue
+                except OSError:
+                    if not self._running:
+                        break
+                    time.sleep(self.heartbeat_interval)
+                    continue
             try:
                 header = sock.recv(4)
                 if not header:
-                    break
+                    raise OSError
                 length = int.from_bytes(header, "big")
                 data = b""
                 while len(data) < length:
                     chunk = sock.recv(length - len(data))
                     if not chunk:
-                        break
+                        raise OSError
                     data += chunk
-                if len(data) != length:
-                    break
                 message = self.protocol.decrypt(data).decode()
                 self.handle_task(message)
             except OSError:
-                break
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+                self._sock = None
+                if not self._running:
+                    break
+                time.sleep(self.heartbeat_interval)
 
     def stop(self) -> None:
         self._running = False
@@ -79,3 +104,20 @@ class MeshNode:
             pass
         if self._thread:
             self._thread.join(timeout=1)
+        if self._heartbeat_thread:
+            self._heartbeat_thread.join(timeout=1)
+
+    def _heartbeat(self) -> None:
+        while self._running:
+            time.sleep(self.heartbeat_interval)
+            if not self._running:
+                break
+            sock = self._sock
+            if sock is None:
+                continue
+            try:
+                message = self.protocol.encrypt(b"HB")
+                packet = len(message).to_bytes(4, "big") + message
+                sock.sendall(packet)
+            except OSError:
+                pass

--- a/tests/test_mesh_reconnect.py
+++ b/tests/test_mesh_reconnect.py
@@ -1,0 +1,37 @@
+import time
+
+from mesh import MeshHub, MeshNode
+
+
+def test_node_reconnects_after_disconnect():
+    key = b"k" * 32
+    hub = MeshHub(key=key)
+    hub.start()
+
+    received: list[str] = []
+
+    def handler(task: str) -> None:
+        received.append(task)
+
+    node = MeshNode(handler, key=key, heartbeat_interval=0.1)
+    address = node.discover(hub.discovery_port, host="127.0.0.1")
+    node.connect(address)
+
+    time.sleep(0.3)
+    hub.distribute_task("one")
+    time.sleep(0.3)
+    assert "one" in received
+
+    with hub._lock:
+        conn = next(iter(hub._nodes))
+        conn.close()
+
+    time.sleep(1.0)
+    hub.distribute_task("two")
+    time.sleep(0.3)
+
+    node.stop()
+    hub.stop()
+
+    assert "two" in received
+


### PR DESCRIPTION
## Summary
- add periodic heartbeat and automatic reconnection in `MeshNode`
- track node heartbeats in `MeshHub` and prune stale connections
- test reconnection behavior when connections drop

## Testing
- `pytest tests/test_mesh_connection.py tests/test_mesh_reconnect.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891927088d88326a40f0cc3f95bd6c3