### PR TITLE
feat: support multiple off peak windows

### DIFF
--- a/eco/scheduler.py
+++ b/eco/scheduler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, time, timedelta
 from threading import Timer
 from typing import Callable, Optional
@@ -12,31 +12,42 @@ from typing import Callable, Optional
 class EcoScheduler:
     """Schedule callables for execution during off‑peak hours.
 
-    Off‑peak hours are defined by a start hour and an end hour.  The window can
-    span midnight (e.g. 22 → 6).  The :meth:`next_run` method computes the next
-    eligible run time and :meth:`schedule` uses :class:`threading.Timer` to
-    execute a callable when the window opens.
+    Off‑peak hours are defined by one or more ``(start_hour, end_hour)``
+    windows.  Each window can span midnight (e.g. ``22 → 6``).  The
+    :meth:`next_run` method computes the next eligible run time and
+    :meth:`schedule` uses :class:`threading.Timer` to execute a callable when
+    a window opens.
     """
 
-    start_hour: int = 22
-    end_hour: int = 6
+    windows: list[tuple[int, int]] = field(default_factory=lambda: [(22, 6)])
 
     def is_off_peak(self, dt: datetime) -> bool:
-        start = time(self.start_hour, 0)
-        end = time(self.end_hour, 0)
-        if self.start_hour < self.end_hour:
-            return start <= dt.time() < end
-        return dt.time() >= start or dt.time() < end
+        for start_hour, end_hour in self.windows:
+            start = time(start_hour, 0)
+            end = time(end_hour, 0)
+            if start_hour < end_hour:
+                if start <= dt.time() < end:
+                    return True
+            else:
+                if dt.time() >= start or dt.time() < end:
+                    return True
+        return False
 
     def next_run(self, now: Optional[datetime] = None) -> datetime:
         now = now or datetime.now()
         if self.is_off_peak(now):
             return now
-        start_time = time(self.start_hour, 0)
-        run_day = now.date()
-        if now.time() >= start_time:
-            run_day += timedelta(days=1)
-        return datetime.combine(run_day, start_time)
+        candidates = []
+        for start_hour, _ in self.windows:
+            start_time = time(start_hour, 0)
+            run_day = now.date()
+            if now.time() < start_time:
+                candidates.append(datetime.combine(run_day, start_time))
+            else:
+                candidates.append(
+                    datetime.combine(run_day + timedelta(days=1), start_time)
+                )
+        return min(candidates)
 
     def schedule(self, func: Callable[[], None], now: Optional[datetime] = None) -> Timer:
         """Schedule ``func`` to run at the next off‑peak time."""

--- a/tests/test_eco_scheduler.py
+++ b/tests/test_eco_scheduler.py
@@ -4,21 +4,40 @@ from eco.scheduler import EcoScheduler
 
 
 def test_next_run_in_off_peak():
-    sched = EcoScheduler(start_hour=22, end_hour=6)
+    sched = EcoScheduler(windows=[(22, 6)])
     now = datetime(2024, 1, 1, 23, 0)
     assert sched.is_off_peak(now)
     assert sched.next_run(now) == now
 
 
 def test_next_run_before_window():
-    sched = EcoScheduler(start_hour=22, end_hour=6)
+    sched = EcoScheduler(windows=[(22, 6)])
     now = datetime(2024, 1, 1, 20, 0)
     expected = datetime(2024, 1, 1, 22, 0)
     assert sched.next_run(now) == expected
 
 
 def test_next_run_after_window():
-    sched = EcoScheduler(start_hour=22, end_hour=6)
+    sched = EcoScheduler(windows=[(22, 6)])
     now = datetime(2024, 1, 1, 7, 0)
     expected = datetime(2024, 1, 1, 22, 0)
     assert sched.next_run(now) == expected
+
+
+def test_overlapping_windows():
+    sched = EcoScheduler(windows=[(1, 4), (3, 5)])
+    inside_overlap = datetime(2024, 1, 1, 3, 30)
+    assert sched.is_off_peak(inside_overlap)
+    after = datetime(2024, 1, 1, 5, 30)
+    expected = datetime(2024, 1, 2, 1, 0)
+    assert sched.next_run(after) == expected
+
+
+def test_cross_midnight_windows():
+    sched = EcoScheduler(windows=[(22, 4), (6, 8)])
+    between_windows = datetime(2024, 1, 1, 5, 0)
+    expected = datetime(2024, 1, 1, 6, 0)
+    assert not sched.is_off_peak(between_windows)
+    assert sched.next_run(between_windows) == expected
+    in_first_window = datetime(2024, 1, 1, 23, 0)
+    assert sched.is_off_peak(in_first_window)


### PR DESCRIPTION
## Summary
- extend eco scheduler to accept multiple off-peak windows
- compute next run and off-peak checks against all windows
- test overlapping and cross-midnight windows

## Testing
- `pytest tests/test_eco_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_6891928068c48326adece65ae8ad6084