### PR TITLE
Add SessionManager backend import tests

### DIFF
--- a/tests/test_control_center_backends.py
+++ b/tests/test_control_center_backends.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def test_backends_importable():
+    importlib.import_module('control_center.backends')
+
+
+from control_center.backends import LocalBackend, SessionManager
+
+
+def test_session_manager_generates_session_id():
+    manager = SessionManager()
+    sid = manager.create('alice', LocalBackend())
+    assert isinstance(sid, str) and sid
+    assert sid in manager._sessions


### PR DESCRIPTION
## Summary
- confirm `control_center.backends` imports dataclasses and secrets helpers for session IDs
- add tests ensuring the backend module imports and `SessionManager` creates session IDs

## Testing
- `python - <<'PY'
import importlib
module_name='control_center.backends'
importlib.import_module(module_name)
print('imported', module_name)
PY`
- `pytest tests/test_control_center_backends.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891948affe08326b05f5824b61515dc