### PR TITLE
Add CPU and memory metrics to TaskManagerAI prompts

### DIFF
--- a/tests/test_task_manager_ai.py
+++ b/tests/test_task_manager_ai.py
@@ -6,9 +6,34 @@ class DummyModel:
         return f"ANALYSIS:{prompt}"
 
 
-def test_analyze_processes_records_prompt():
+class DummyProcess:
+    def __init__(self, name: str, cpu: float, mem: float):
+        self.info = {"name": name}
+        self._cpu = cpu
+        self._mem = mem
+
+    def cpu_percent(self, interval=None) -> float:  # pragma: no cover - simple wrapper
+        return self._cpu
+
+    def memory_percent(self) -> float:  # pragma: no cover - simple wrapper
+        return self._mem
+
+
+class DummyPsutil:
+    def process_iter(self, attrs):  # pragma: no cover - deterministic
+        return [
+            DummyProcess("proc1", 1.0, 2.0),
+            DummyProcess("proc2", 3.0, 4.0),
+        ]
+
+
+def test_analyze_processes_records_prompt(monkeypatch):
     model = DummyModel()
     tm = TaskManagerAI(model)
+    # Stub psutil so metrics are deterministic
+    monkeypatch.setattr("windows_ai.task_manager.psutil", DummyPsutil())
     result = tm.analyze_processes(["proc1", "proc2"])
-    assert result == "ANALYSIS:analyze: proc1, proc2"
-    assert tm.get_queries() == ["analyze: proc1, proc2"]
+    expected = "analyze: proc1 (cpu=1.0, mem=2.0), proc2 (cpu=3.0, mem=4.0)"
+    assert result == f"ANALYSIS:{expected}"
+    assert tm.get_queries() == [expected]
+

--- a/windows_ai/task_manager.py
+++ b/windows_ai/task_manager.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import List, Any
 
+import psutil
+
 
 class TaskManagerAI:
     """Small helper that analyzes process lists via a model."""
@@ -15,7 +17,27 @@ class TaskManagerAI:
     def analyze_processes(self, processes: List[str]) -> str:
         """Return model analysis for the provided process names."""
 
-        prompt = "analyze: " + ", ".join(processes)
+        # Gather CPU and memory metrics for each requested process name
+        metrics = {}
+        for proc in psutil.process_iter(["name"]):
+            name = proc.info.get("name")
+            if name in processes and name not in metrics:
+                try:
+                    cpu = proc.cpu_percent(interval=None)
+                except Exception:
+                    cpu = 0.0
+                try:
+                    mem = proc.memory_percent()
+                except Exception:
+                    mem = 0.0
+                metrics[name] = (cpu, mem)
+
+        parts = []
+        for name in processes:
+            cpu, mem = metrics.get(name, (0.0, 0.0))
+            parts.append(f"{name} (cpu={cpu:.1f}, mem={mem:.1f})")
+
+        prompt = "analyze: " + ", ".join(parts)
         self._queries.append(prompt)
         return self.model.generate(prompt)
 


### PR DESCRIPTION
## Summary
- collect per-process CPU and memory data with psutil and include it in analysis prompts
- log and test queries that contain these metrics

## Testing
- `pytest tests/test_task_manager_ai.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68919482be148326a7a67c4750e3a41b