### PR TITLE
Add plugin uninstall support with dependency cleanup

### DIFF
--- a/plugins/manager.py
+++ b/plugins/manager.py
@@ -171,6 +171,76 @@ class PluginManager:
             else:
                 raise
 
+    # -------------------------------------------------------------- uninstallation
+    def uninstall(
+        self,
+        plugin: Plugin,
+        messagebox=None,
+        _stack: set[str] | None = None,
+    ) -> None:
+        """Uninstall a plugin and remove unused dependencies."""
+
+        if plugin.name not in self._installed:
+            return
+
+        if _stack is None:
+            _stack = set()
+        if plugin.name in _stack:
+            raise ValueError("Cyclic dependency detected")
+        _stack.add(plugin.name)
+
+        try:
+            uninstall_args = self._build_uninstall_args(plugin.command)
+            if uninstall_args:
+                self.sandbox_run(uninstall_args)
+            self._installed.discard(plugin.name)
+        except Exception as exc:  # pragma: no cover - subprocess path
+            if messagebox is not None:
+                messagebox.showerror(
+                    "Plugin Uninstall", f"Failed to uninstall {plugin.name}: {exc}"
+                )
+            else:
+                raise
+
+        # Remove dependencies if nothing else requires them
+        for dep_name in plugin.dependencies:
+            dep = self.get_plugin(dep_name)
+            if dep and dep.name in self._installed:
+                still_needed = any(
+                    dep_name in p.dependencies
+                    for p in self.plugins
+                    if p.name in self._installed
+                )
+                if not still_needed:
+                    self.uninstall(dep, messagebox, _stack)
+
+        _stack.remove(plugin.name)
+
+    def _build_uninstall_args(self, command: str) -> list[str] | None:
+        """Derive an uninstall command from the installation command."""
+
+        raw_args = shlex.split(command, posix=os.name != "nt")
+        if not raw_args:
+            return None
+
+        tool = raw_args[0]
+        if tool == "pip":
+            pkgs = [arg for arg in raw_args[2:] if not arg.startswith("-")]
+            if not pkgs:
+                return None
+            return ["pip", "uninstall", "-y", *pkgs]
+        if tool == "npm":
+            pkgs = [arg for arg in raw_args[2:] if not arg.startswith("-")]
+            if not pkgs:
+                return None
+            return ["npm", "uninstall", *pkgs]
+        if tool == "brew":
+            pkgs = [arg for arg in raw_args[2:] if not arg.startswith("-")]
+            if not pkgs:
+                return None
+            return ["brew", "uninstall", *pkgs]
+        return None
+
 
 __all__ = ["Plugin", "PluginManager", "load_catalog", "SANDBOX_DIR"]
 

--- a/tests/test_plugin_uninstall.py
+++ b/tests/test_plugin_uninstall.py
@@ -1,0 +1,73 @@
+import pytest
+
+from plugins.manager import Plugin, PluginManager
+
+
+def test_uninstall_runs_command_and_updates_state(monkeypatch):
+    plugin = Plugin(name="Foo", description="", command="pip install Foo")
+    manager = PluginManager()
+    manager.plugins = [plugin]
+
+    calls = []
+
+    def fake_run(args):
+        calls.append(args)
+
+    monkeypatch.setattr(manager, "sandbox_run", fake_run)
+
+    manager.install(plugin)
+    assert plugin.name in manager._installed
+
+    manager.uninstall(plugin)
+    assert plugin.name not in manager._installed
+    assert calls == [["pip", "install", "Foo"], ["pip", "uninstall", "-y", "Foo"]]
+
+
+def test_uninstall_removes_unused_dependencies(monkeypatch):
+    dep = Plugin(name="Dep", description="", command="pip install Dep")
+    main = Plugin(name="Main", description="", command="pip install Main", dependencies=["Dep"])
+    manager = PluginManager()
+    manager.plugins = [dep, main]
+
+    calls = []
+    monkeypatch.setattr(manager, "sandbox_run", lambda args: calls.append(args))
+
+    manager.install(main)
+    assert manager._installed == {"Dep", "Main"}
+
+    manager.uninstall(main)
+    assert manager._installed == set()
+    assert calls == [
+        ["pip", "install", "Dep"],
+        ["pip", "install", "Main"],
+        ["pip", "uninstall", "-y", "Main"],
+        ["pip", "uninstall", "-y", "Dep"],
+    ]
+
+
+def test_uninstall_retains_shared_dependencies(monkeypatch):
+    dep = Plugin(name="Dep", description="", command="pip install Dep")
+    one = Plugin(name="One", description="", command="pip install One", dependencies=["Dep"])
+    two = Plugin(name="Two", description="", command="pip install Two", dependencies=["Dep"])
+    manager = PluginManager()
+    manager.plugins = [dep, one, two]
+
+    calls = []
+    monkeypatch.setattr(manager, "sandbox_run", lambda args: calls.append(args))
+
+    manager.install(one)
+    manager.install(two)
+    assert manager._installed == {"Dep", "One", "Two"}
+
+    calls.clear()
+    manager.uninstall(one)
+    assert manager._installed == {"Dep", "Two"}
+    assert calls == [["pip", "uninstall", "-y", "One"]]
+
+    calls.clear()
+    manager.uninstall(two)
+    assert manager._installed == set()
+    assert calls == [
+        ["pip", "uninstall", "-y", "Two"],
+        ["pip", "uninstall", "-y", "Dep"],
+    ]


### PR DESCRIPTION
## Summary
- implement `PluginManager.uninstall` to run uninstall command and remove unused dependencies
- add `_build_uninstall_args` helper for pip/npm/brew
- cover uninstall behaviour and dependency handling with tests

## Testing
- `pytest tests/test_plugin_uninstall.py tests/test_plugin_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6891944ebd688326be28f8c07877e0cc