### PR TITLE
ci: run tests for all npm workspaces

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,21 @@
+name: Node Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   ],
   "scripts": {
     "build": "echo \"(optional) build all workspaces\"",
-    "test": "npm test -w apps/actions-api"
+    "test": "npm test -ws"
   }
 }


### PR DESCRIPTION
## Summary
- run `npm test -ws` from the root package to exercise every workspace
- add GitHub Actions workflow to run `npm test` on push and PRs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68919486a4448326b04877b9776fa112