### PR TITLE
Add workflow dataclass serialization test

### DIFF
--- a/tests/test_workflow_dataclasses.py
+++ b/tests/test_workflow_dataclasses.py
@@ -1,0 +1,11 @@
+from automation.workflow import Step, Workflow, save_workflow, load_workflow
+
+
+def test_workflow_serialization(tmp_path):
+    step = Step(id="start", name="Start", next=["end"])
+    workflow = Workflow(steps={"start": step})
+    path = tmp_path / "workflow.yaml"
+    save_workflow(workflow, path)
+    loaded = load_workflow(path)
+    assert loaded.steps["start"].name == "Start"
+    assert loaded.steps["start"].next == ["end"]


### PR DESCRIPTION
## Summary
- ensure `automation.workflow` imports dataclasses for defining `Step` and `Workflow`
- add a serialization round-trip test for the `Workflow` dataclasses

## Testing
- `pytest tests/test_workflow_dataclasses.py`


------
https://chatgpt.com/codex/tasks/task_e_68919490dd0c8326ac184c807447ba9d