### PR TITLE
Handle missing paths and copy errors

### DIFF
--- a/model_discovery/discovery.py
+++ b/model_discovery/discovery.py
@@ -6,7 +6,13 @@ from typing import List
 
 
 def discover_models(path: str, extension: str = ".model") -> List[str]:
-    """Return a list of model files in *path* matching *extension*."""
+    """Return a list of model files in *path* matching *extension*.
+
+    If *path* does not exist an empty list is returned.
+    """
+
+    if not os.path.isdir(path):
+        return []
 
     return [
         os.path.join(path, name)
@@ -16,7 +22,15 @@ def discover_models(path: str, extension: str = ".model") -> List[str]:
 
 
 def download_model(src: str, dest: str) -> str:
-    """Copy a model file from *src* to *dest* and return destination path."""
+    """Copy a model file from *src* to *dest* and return destination path.
 
-    shutil.copyfile(src, dest)
+    Any copy errors result in an empty string being returned.  The destination
+    directory is created if it does not already exist.
+    """
+
+    os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+    try:
+        shutil.copyfile(src, dest)
+    except OSError:
+        return ""
     return dest

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -12,6 +12,19 @@ def test_discover_models(tmp_path):
 def test_download_model(tmp_path):
     src = tmp_path / "src.model"
     src.write_text("data")
-    dest = tmp_path / "dest.model"
+    dest = tmp_path / "sub" / "dest.model"
     download_model(str(src), str(dest))
     assert dest.read_text() == "data"
+
+
+def test_discover_models_missing_path(tmp_path):
+    missing = tmp_path / "missing"
+    assert discover_models(str(missing)) == []
+
+
+def test_download_model_failure(tmp_path):
+    src = tmp_path / "missing.model"
+    dest = tmp_path / "dest.model"
+    result = download_model(str(src), str(dest))
+    assert result == ""
+    assert not dest.exists()


### PR DESCRIPTION
## Summary
- guard `discover_models` against missing directories
- ensure `download_model` creates destination folders and handles copy failures
- test model discovery for nonexistent directories and failed copies

## Testing
- `pytest tests/test_model_discovery.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68919496ea308326a75abcafb1fd7b72