### PR TITLE
docs: document merge queue workflow

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,14 @@
+queue_rules:
+  - name: default
+    conditions:
+      - '#approved-reviews-by>=1'
+
+pull_request_rules:
+  - name: default merge queue
+    conditions:
+      - base=main
+      - label=ready-to-merge
+    actions:
+      queue:
+        name: default
+        merge_method: squash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+Thanks for your interest in improving Windows AI!
+
+## Pull Requests
+
+- Keep your branch up to date with `main`. The `main` branch is protected and requires pull requests to be up to date before merging.
+- Pull requests are merged via the **merge queue**. Add the `ready-to-merge` label to enqueue your PR and let Mergify handle the merge once checks pass.
+- **Do not merge manually.** All changes must go through the queue.
+
+Please ensure tests pass locally before requesting a review.


### PR DESCRIPTION
## Summary
- add Mergify configuration to queue approved pull requests
- document requirement to enqueue PRs instead of merging manually

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921f033ee48326b74954d4ce87d5a4