### PR TITLE
Add pre-commit configuration and CI enforcement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+  test:
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with formatting and linting hooks
- document pre-commit setup in contributing guide
- run pre-commit in GitHub Actions CI

## Testing
- `pre-commit run --all-files` *(fails: certificate verify failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892212918cc8326b7cad4792d18a4de