### PR TITLE
feat(eco): support multiple off-peak windows

### DIFF
--- a/eco/scheduler.py
+++ b/eco/scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, time, timedelta
 from threading import Timer
-from typing import Callable, Optional
+from typing import Callable, Iterable, List, Optional, Tuple
 
 
 @dataclass
@@ -13,23 +13,54 @@ class EcoScheduler:
     """Schedule callables for execution during off‑peak hours.
 
     Off‑peak hours are defined by one or more ``(start_hour, end_hour)``
-    windows.  Each window can span midnight (e.g. ``22 → 6``).  The
+    windows.  Each window may span midnight (e.g. ``22 → 6``).  The
     :meth:`next_run` method computes the next eligible run time and
-    :meth:`schedule` uses :class:`threading.Timer` to execute a callable when
-    a window opens.
+    :meth:`schedule` uses :class:`threading.Timer` to execute a callable when a
+    window opens.
     """
 
-    windows: list[tuple[int, int]] = field(default_factory=lambda: [(22, 6)])
+    windows: List[Tuple[int, int]]
 
+    def __init__(
+        self,
+        windows: Optional[Iterable[Tuple[int, int]]] = None,
+        *,
+        start_hour: int = 22,
+        end_hour: int = 6,
+    ) -> None:
+        self.windows = list(windows) if windows is not None else [(start_hour, end_hour)]
+
+    # ------------------------------------------------------------------
+    # Backwards compatibility helpers for existing code using the old API
+    @property
+    def start_hour(self) -> int:
+        return self.windows[0][0]
+
+    @start_hour.setter
+    def start_hour(self, value: int) -> None:
+        _, end = self.windows[0]
+        self.windows[0] = (value, end)
+
+    @property
+    def end_hour(self) -> int:
+        return self.windows[0][1]
+
+    @end_hour.setter
+    def end_hour(self, value: int) -> None:
+        start, _ = self.windows[0]
+        self.windows[0] = (start, value)
+
+    # ------------------------------------------------------------------
     def is_off_peak(self, dt: datetime) -> bool:
+        t = dt.time()
         for start_hour, end_hour in self.windows:
             start = time(start_hour, 0)
             end = time(end_hour, 0)
             if start_hour < end_hour:
-                if start <= dt.time() < end:
+                if start <= t < end:
                     return True
-            else:
-                if dt.time() >= start or dt.time() < end:
+            else:  # window spans midnight
+                if t >= start or t < end:
                     return True
         return False
 
@@ -37,16 +68,14 @@ class EcoScheduler:
         now = now or datetime.now()
         if self.is_off_peak(now):
             return now
-        candidates = []
+
+        candidates: List[datetime] = []
         for start_hour, _ in self.windows:
             start_time = time(start_hour, 0)
             run_day = now.date()
-            if now.time() < start_time:
-                candidates.append(datetime.combine(run_day, start_time))
-            else:
-                candidates.append(
-                    datetime.combine(run_day + timedelta(days=1), start_time)
-                )
+            if now.time() >= start_time:
+                run_day += timedelta(days=1)
+            candidates.append(datetime.combine(run_day, start_time))
         return min(candidates)
 
     def schedule(self, func: Callable[[], None], now: Optional[datetime] = None) -> Timer:

--- a/tests/test_eco_scheduler.py
+++ b/tests/test_eco_scheduler.py
@@ -25,19 +25,17 @@ def test_next_run_after_window():
 
 
 def test_overlapping_windows():
-    sched = EcoScheduler(windows=[(1, 4), (3, 5)])
-    inside_overlap = datetime(2024, 1, 1, 3, 30)
-    assert sched.is_off_peak(inside_overlap)
-    after = datetime(2024, 1, 1, 5, 30)
-    expected = datetime(2024, 1, 2, 1, 0)
-    assert sched.next_run(after) == expected
+    sched = EcoScheduler(windows=[(1, 5), (4, 8)])
+    assert sched.is_off_peak(datetime(2024, 1, 1, 4, 30))
+    now = datetime(2024, 1, 1, 0, 0)
+    expected = datetime(2024, 1, 1, 1, 0)
+    assert sched.next_run(now) == expected
 
 
 def test_cross_midnight_windows():
-    sched = EcoScheduler(windows=[(22, 4), (6, 8)])
-    between_windows = datetime(2024, 1, 1, 5, 0)
-    expected = datetime(2024, 1, 1, 6, 0)
-    assert not sched.is_off_peak(between_windows)
-    assert sched.next_run(between_windows) == expected
-    in_first_window = datetime(2024, 1, 1, 23, 0)
-    assert sched.is_off_peak(in_first_window)
+    sched = EcoScheduler(windows=[(22, 2), (3, 5)])
+    assert sched.is_off_peak(datetime(2024, 1, 1, 23, 30))
+    assert sched.is_off_peak(datetime(2024, 1, 2, 4, 0))
+    now = datetime(2024, 1, 2, 2, 30)
+    expected = datetime(2024, 1, 2, 3, 0)
+    assert sched.next_run(now) == expected


### PR DESCRIPTION
## Summary
- allow `EcoScheduler` to accept multiple `(start_hour, end_hour)` windows
- handle overlapping and cross-midnight windows in `is_off_peak` and `next_run`
- add tests for multiple window scenarios

## Testing
- `pytest tests/test_eco_scheduler.py`

------
https://chatgpt.com/codex/tasks/task_e_68919463e9f883268d389d4cd5c6af63