### PR TITLE
ci: add PR merge conflict check workflow

### DIFF
--- a/.github/workflows/pr-merge-conflict.yml
+++ b/.github/workflows/pr-merge-conflict.yml
@@ -1,0 +1,33 @@
+name: PR Merge Conflict Check
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  merge-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Attempt merge with main
+        id: merge
+        continue-on-error: true
+        run: |
+          git fetch origin main
+          git merge --no-commit origin/main
+      - name: Comment on conflicts
+        if: steps.merge.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const {owner, repo} = context.repo;
+            const issue_number = context.issue.number;
+            const body = '⚠️ Merge conflicts detected when merging `main` into this branch. Please resolve conflicts.';
+            await github.rest.issues.createComment({owner, repo, issue_number, body});
+      - name: Fail on conflict
+        if: steps.merge.outcome == 'failure'
+        run: exit 1

--- a/codex/GITHUB_WORKFLOWS/pr-merge-conflict.yml
+++ b/codex/GITHUB_WORKFLOWS/pr-merge-conflict.yml
@@ -1,0 +1,33 @@
+name: PR Merge Conflict Check
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  merge-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Attempt merge with main
+        id: merge
+        continue-on-error: true
+        run: |
+          git fetch origin main
+          git merge --no-commit origin/main
+      - name: Comment on conflicts
+        if: steps.merge.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const {owner, repo} = context.repo;
+            const issue_number = context.issue.number;
+            const body = '⚠️ Merge conflicts detected when merging `main` into this branch. Please resolve conflicts.';
+            await github.rest.issues.createComment({owner, repo, issue_number, body});
+      - name: Fail on conflict
+        if: steps.merge.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- add workflow to detect merge conflicts against main and comment on issues

## Testing
- `npm test`
- `pytest -q`
- `npx @redocly/cli lint openapi/windows-ai.yaml` *(fails: npm error canceled)*
- `npx commitlint --from=HEAD~1 --to=HEAD` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68926ddab7cc8326a71f53e32e079a01