### PR TITLE
chore: use Node 20 in CI workflows

### DIFF
--- a/.github/workflows/ci-windows-powershell.yml
+++ b/.github/workflows/ci-windows-powershell.yml
@@ -15,7 +15,7 @@ jobs:
       # Setup Node with npm cache
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
 

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- use Node 20 LTS for Node tests workflow
- use Node 20 LTS for Windows CI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68926fa3f1548326ad2234f87dd3bb97