### PR TITLE
Specify Python 3.11 in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- pin tests workflow to Python 3.11

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68926fa7d27c8326a4533f111ef98cbe