### PR TITLE
Add CI workflow for tests, lint, type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest ruff mypy
+      - name: Lint
+        run: ruff check .
+      - name: Type check
+        run: mypy .
+      - name: Test
+        run: pytest
+
+  node:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: '**/package-lock.json'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Type check
+        run: npm run typecheck --if-present
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Summary
- add CI workflow running Python and Node tests with linting and type checking

## Testing
- `pytest`
- `ruff check .` *(fails: Found 23 errors)*
- `mypy .` *(fails: Found 9 errors in 7 files)*
- `npm test`
- `npm run lint --if-present` *(fails: No output)*
- `npm run typecheck --if-present` *(fails: No output)*


------
https://chatgpt.com/codex/tasks/task_e_689221c6b2c483268f7f29ae5cc26b3a