### PR TITLE
feat: add HTTP-enabled cloud backend

### DIFF
--- a/search/backends.py
+++ b/search/backends.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+import requests
+
 from .embeddings import embed
 from .index import SearchIndex
 
@@ -31,19 +33,34 @@ class LocalBackend(SearchBackend):
 
 
 class CloudBackend(SearchBackend):
-    """Placeholder backend representing a remote service."""
+    """Backend representing a remote search service."""
 
-    def __init__(self, endpoint: str):
-        self.endpoint = endpoint
-        self._indexed: Dict[str, str] = {}
+    def __init__(self, endpoint: str, timeout: float = 5.0):
+        self.endpoint = endpoint.rstrip("/")
+        self.timeout = timeout
 
     def index(self, docs: Dict[str, str]) -> None:
-        # In a real implementation this would send docs to the service.
-        self._indexed.update(docs)
+        try:
+            res = requests.post(
+                f"{self.endpoint}/index", json=docs, timeout=self.timeout
+            )
+            res.raise_for_status()
+        except requests.exceptions.Timeout as e:  # pragma: no cover - network
+            raise TimeoutError("Index request timed out") from e
+        except requests.RequestException as e:  # pragma: no cover - network
+            raise RuntimeError(f"Index request failed: {e}") from e
 
     def search(self, query: str, top_k: int = 5) -> List[str]:
-        # Real implementation would call the remote service. We return all ids
-        # when a query is provided to keep behaviour deterministic for tests.
-        if not query:
-            return []
-        return list(self._indexed.keys())[:top_k]
+        try:
+            res = requests.post(
+                f"{self.endpoint}/search",
+                json={"query": query, "top_k": top_k},
+                timeout=self.timeout,
+            )
+            res.raise_for_status()
+            data = res.json()
+            return data.get("results", [])
+        except requests.exceptions.Timeout as e:  # pragma: no cover - network
+            raise TimeoutError("Search request timed out") from e
+        except requests.RequestException as e:  # pragma: no cover - network
+            raise RuntimeError(f"Search request failed: {e}") from e

--- a/tests/test_cloud_backend.py
+++ b/tests/test_cloud_backend.py
@@ -1,0 +1,48 @@
+import pytest
+import requests
+
+from search.backends import CloudBackend
+
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+    def json(self):
+        return self._data
+
+
+def test_cloud_backend_index_and_search(monkeypatch):
+    calls = []
+
+    def fake_post(url, json=None, timeout=None):
+        calls.append((url, json))
+        if url.endswith("/search"):
+            return DummyResponse({"results": ["a", "b"]})
+        return DummyResponse({})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    backend = CloudBackend("http://api.test")
+    backend.index({"a": "foo"})
+    results = backend.search("bar", top_k=2)
+
+    assert calls[0][0] == "http://api.test/index"
+    assert calls[0][1] == {"a": "foo"}
+    assert results == ["a", "b"]
+
+
+def test_cloud_backend_timeout(monkeypatch):
+    def fake_post(url, json=None, timeout=None):
+        raise requests.Timeout("boom")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    backend = CloudBackend("http://api.test")
+    with pytest.raises(TimeoutError):
+        backend.search("baz")


### PR DESCRIPTION
## Summary
- implement HTTP requests with error and timeout handling for CloudBackend
- add tests mocking network calls for CloudBackend

## Testing
- `pytest tests/test_cloud_backend.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689194744238832691ce7bf51c724902