### PR TITLE
Add simple GUI model and integrate with GuiCore

### DIFF
--- a/gui/core.py
+++ b/gui/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Protocol, List, Dict, Callable, Optional
 
 from search import SearchEngine
+from .simple_model import SimpleModel
 
 
 class Model(Protocol):
@@ -99,21 +100,7 @@ class GuiCore:
     """Minimal GUI core placeholder with overlays and hotkeys."""
 
     def __init__(self, model: Optional[Model] = None):
-        """Initialize the GUI core.
-
-        If no model is provided a :class:`~gui.simple_model.SimpleModel`
-        instance is created. This keeps the core usable out of the box
-        while still allowing custom models to be injected for tests or
-        other purposes.
-        """
-
-        if model is None:
-            # Import locally to avoid circular imports during type checking.
-            from .simple_model import SimpleModel
-
-            model = SimpleModel()
-
-        self.model = model
+        self.model = model if model is not None else SimpleModel()
         self.launched = False
         self._logs: List[str] = []
         self.overlays: Dict[str, OverlayWidget] = {}

--- a/gui/simple_model.py
+++ b/gui/simple_model.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 class SimpleModel:
-    """A minimal concrete model used for testing and default behavior."""
+    """Very small model used for tests and examples."""
 
     def generate(self, prompt: str) -> str:
-        """Return a deterministic response for a given prompt."""
-        return f"Echo: {prompt}"
+        """Return a deterministic response for *prompt*."""
+        return prompt.upper()

--- a/tests/test_gui_model.py
+++ b/tests/test_gui_model.py
@@ -1,0 +1,9 @@
+from gui.core import GuiCore
+from gui.simple_model import SimpleModel
+
+
+def test_chat_returns_model_output():
+    model = SimpleModel()
+    gui = GuiCore(model)
+    message = "hello world"
+    assert gui.chat(message) == model.generate(message)


### PR DESCRIPTION
## Summary
- introduce `SimpleModel` with a basic `generate` implementation for GUI tests
- allow `GuiCore` to default to `SimpleModel` and relay model responses in `chat`
- add unit test ensuring `GuiCore.chat` returns the model's output

## Testing
- `pytest tests/test_gui_model.py tests/test_gui_core.py -q`
- `pytest tests/test_search.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891946fffe88326959b31580a73596a