### PR TITLE
Stream updater downloads with checksum verification

### DIFF
--- a/tests/test_updater_download.py
+++ b/tests/test_updater_download.py
@@ -1,0 +1,45 @@
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from updater import Updater
+
+
+def make_server(tmp_path: Path, version: str, data: bytes) -> tuple[str, str]:
+    """Create a fake update server structure returning (base_url, checksum)."""
+    base = tmp_path / "server"
+    pkg_dir = base / version
+    pkg_dir.mkdir(parents=True)
+    (pkg_dir / "package.zip").write_bytes(data)
+    checksum = hashlib.sha256(data).hexdigest()
+    return base.as_uri(), checksum
+
+
+def test_download_emits_progress(tmp_path):
+    data = b"a" * 20000
+    base_url, checksum = make_server(tmp_path, "1.0", data)
+    dest = tmp_path / "pkg.zip"
+    updater = Updater(base_url=base_url)
+    calls: list[tuple[int, int]] = []
+
+    def progress(downloaded: int, total: int) -> None:
+        calls.append((downloaded, total))
+
+    updater.download("1.0", dest, progress=progress, checksum=checksum)
+
+    assert calls, "progress callback was not invoked"
+    assert calls[-1] == (len(data), len(data))
+    assert dest.read_bytes() == data
+
+
+def test_download_checksum_failure(tmp_path):
+    data = b"test"
+    base_url, checksum = make_server(tmp_path, "2.0", data)
+    dest = tmp_path / "pkg.zip"
+    updater = Updater(base_url=base_url)
+
+    with pytest.raises(ValueError):
+        updater.download("2.0", dest, checksum="0" * 64)
+
+    assert not dest.exists()

--- a/updater/__init__.py
+++ b/updater/__init__.py
@@ -12,6 +12,7 @@ import hashlib
 import shutil
 import subprocess
 import tempfile
+from typing import Callable
 from urllib.request import urlopen
 
 __all__ = ["Updater"]
@@ -63,13 +64,68 @@ class Updater:
         except Exception:  # pragma: no cover - offline fallback
             return self.current_version
 
-    def download(self, version: str, dest: Path | str) -> Path:
-        """Download the update package for *version* to *dest*."""
+    def download(
+        self,
+        version: str,
+        dest: Path | str,
+        progress: Callable[[int, int], None] | None = None,
+        checksum: str | None = None,
+    ) -> Path:
+        """Download the update package for *version* to *dest*.
+
+        Parameters
+        ----------
+        version:
+            Version identifier to download.
+        dest:
+            Destination file path.
+        progress:
+            Optional callback receiving ``bytes_downloaded`` and
+            ``total_bytes`` for progress reporting.
+        checksum:
+            Expected SHA256 checksum of the file. If provided, the
+            downloaded data is verified and a :class:`ValueError` is
+            raised on mismatch.
+        """
 
         dest_path = Path(dest)
-        with urlopen(f"{self.base_url}/{version}/package.zip") as fh:
-            dest_path.write_bytes(fh.read())
+        with urlopen(f"{self.base_url}/{version}/package.zip") as resp:
+            header = None
+            if hasattr(resp, "getheader"):
+                try:
+                    header = resp.getheader("Content-Length")
+                except Exception:
+                    header = None
+            elif hasattr(resp, "headers"):
+                header = resp.headers.get("Content-Length")
+            total = int(header or 0)
+            downloaded = 0
+            sha = hashlib.sha256()
+            with open(dest_path, "wb") as fh:
+                while True:
+                    chunk = resp.read(8192)
+                    if not chunk:
+                        break
+                    fh.write(chunk)
+                    sha.update(chunk)
+                    downloaded += len(chunk)
+                    if progress:
+                        progress(downloaded, total)
+
+        if checksum and sha.hexdigest().lower() != checksum.lower():
+            dest_path.unlink(missing_ok=True)
+            raise ValueError("Checksum mismatch for downloaded package")
+
         return dest_path
+
+    def verify_checksum(self, file_path: Path | str, expected: str) -> bool:
+        """Verify the SHA256 checksum of ``file_path`` against ``expected``."""
+
+        h = hashlib.sha256()
+        with open(file_path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(8192), b""):
+                h.update(chunk)
+        return h.hexdigest().lower() == expected.lower()
 
     def verify_signature(self, file_path: Path | str, version: str) -> bool:
         """Verify the SHA256 signature of *file_path* for *version*."""
@@ -130,12 +186,28 @@ class Updater:
         if self.rollback_script.exists():
             subprocess.run(["pwsh", str(self.rollback_script)], check=True)
 
-    def apply_update(self, package: Path | str) -> None:
-        """Apply an update package with automatic rollback on failure."""
+    def apply_update(
+        self, package: Path | str, checksum: str | None = None
+    ) -> None:
+        """Apply an update package with automatic rollback on failure.
+
+        Parameters
+        ----------
+        package:
+            Path to the update package to install.
+        checksum:
+            Optional expected SHA256 hash. If provided, the package is
+            verified before installation and a :class:`ValueError` is
+            raised when it does not match.
+        """
+
+        package_path = Path(package)
+        if checksum and not self.verify_checksum(package_path, checksum):
+            raise ValueError("Checksum mismatch for package")
 
         snapshot = self.create_snapshot()
         try:
-            self.run_install(Path(package))
+            self.run_install(package_path)
         except Exception:
             self.rollback(snapshot)
             raise


### PR DESCRIPTION
## Summary
- Stream update packages in chunks with optional progress callbacks and checksum validation
- Verify package checksums before running the installer
- Add tests covering download progress callbacks and checksum mismatch handling

## Testing
- `pytest tests/test_updater_download.py tests/test_updater_rollback.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68919499f2f08326849d0034684544d6