### PR TITLE
feat: add audio processing flow

### DIFF
--- a/domains/audio_processing.py
+++ b/domains/audio_processing.py
@@ -5,44 +5,115 @@ local processing and external API calls.
 """
 
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
-def input_processor(audio: Any) -> Any:
+# Duration threshold (in seconds) beyond which processing is delegated to a
+# remote API rather than handled locally.  The value is intentionally small for
+# demonstration purposes.
+REMOTE_THRESHOLD = 5.0
+
+
+def input_processor(audio: Any) -> Dict[str, Any]:
     """Prepare ``audio`` data for downstream consumption.
 
-    Implementations should handle resampling, noise reduction, and deciding
-    whether to use on-device audio models or route data to APIs.
+    The stub inspects ``audio`` and determines whether the data should be
+    handled locally or sent to a remote API.  ``audio`` may be any object but
+    tests primarily provide a dictionary with a ``duration`` field measured in
+    seconds.  If ``duration`` exceeds :data:`REMOTE_THRESHOLD` the audio will be
+    routed to a remote service.
     """
 
-    return audio
+    if isinstance(audio, dict):
+        duration = float(audio.get("duration", 0))
+        data = audio.get("data")
+    else:
+        # Fallback: treat the length of the input as milliseconds and convert
+        # to seconds.  This keeps the example functional for simple inputs like
+        # byte strings while remaining light-weight.
+        duration = len(audio) / 1000 if hasattr(audio, "__len__") else 0
+        data = audio
+
+    use_remote = duration > REMOTE_THRESHOLD
+    return {"data": data, "duration": duration, "use_remote": use_remote}
 
 
-def task_planner(processed_audio: Any) -> Dict[str, Any]:
+def task_planner(processed_audio: Dict[str, Any]) -> Dict[str, Any]:
     """Determine the audio processing steps to execute.
 
-    The planner identifies tasks suited for local models and those that require
-    remote services.
+    The planner creates a simple plan containing a single transcription step
+    and records whether the step should be executed locally or remotely based on
+    the ``use_remote`` flag provided by :func:`input_processor`.
     """
 
-    return {"plan": []}
+    mode = "remote" if processed_audio.get("use_remote") else "local"
+    steps = [
+        {
+            "type": "transcribe",
+            "mode": mode,
+            "audio": processed_audio.get("data"),
+        }
+    ]
+    return {"steps": steps}
 
 
 def executor(plan: Dict[str, Any]) -> Dict[str, Any]:
     """Execute the planned audio processing steps.
 
-    Each step should be run using local capabilities or delegated to an external
-    API when appropriate.
+    For each step, the executor chooses between a local implementation and a
+    mocked remote API call.  Real implementations would perform heavy audio
+    processing or make HTTP requests to external services.
     """
 
-    return {"results": []}
+    results: List[Dict[str, Any]] = []
+    for step in plan.get("steps", []):
+        mode = step.get("mode")
+        if mode == "local":
+            output = _local_transcribe(step.get("audio"))
+        else:
+            output = _call_remote_api(step.get("audio"))
+        results.append({"type": step.get("type"), "mode": mode, "output": output})
+
+    return {"results": results}
 
 
 def result_aggregator(results: Dict[str, Any]) -> Dict[str, Any]:
     """Merge outputs from audio processing tasks.
 
-    This function should compile results from both local models and APIs into a
-    coherent structure.
+    The aggregator combines individual step results into a single transcript and
+    keeps track of the origin of each contribution.  It returns a dictionary
+    containing the merged transcript and a list identifying whether each step
+    was processed locally or via a remote API.
     """
 
-    return results
+    transcripts = []
+    modes = []
+    for item in results.get("results", []):
+        transcripts.append(item.get("output", ""))
+        modes.append(item.get("mode"))
+
+    return {"transcript": " ".join(transcripts).strip(), "modes": modes}
+
+
+def _local_transcribe(audio: Any) -> str:
+    """Placeholder implementation of a local transcription model."""
+
+    # A realistic implementation would load and run an on-device model.  We keep
+    # the example light-weight and deterministic for testing.
+    return "local transcript"
+
+
+def _call_remote_api(audio: Any) -> str:
+    """Placeholder that simulates a remote transcription API call."""
+
+    # The real function would send ``audio`` to a remote service using HTTP
+    # requests.  Importing ``requests`` here keeps the dependency optional until
+    # remote execution is actually attempted.
+    import requests  # type: ignore
+
+    response = requests.post(
+        "https://example.com/api/transcribe", json={"audio": "<binary>"}
+    )
+    response.raise_for_status()
+    data = response.json()
+    return data.get("transcription", "")

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -1,0 +1,34 @@
+import domains.audio_processing as ap
+
+
+def test_local_processing():
+    audio = {"data": b"123", "duration": 2}
+    processed = ap.input_processor(audio)
+    assert processed["use_remote"] is False
+
+    plan = ap.task_planner(processed)
+    assert plan["steps"][0]["mode"] == "local"
+
+    results = ap.executor(plan)
+    assert results["results"][0]["mode"] == "local"
+
+    aggregated = ap.result_aggregator(results)
+    assert aggregated["transcript"] == "local transcript"
+    assert aggregated["modes"] == ["local"]
+
+
+def test_remote_processing(monkeypatch):
+    audio = {"data": b"123", "duration": 10}
+    processed = ap.input_processor(audio)
+    assert processed["use_remote"] is True
+
+    plan = ap.task_planner(processed)
+    assert plan["steps"][0]["mode"] == "remote"
+
+    monkeypatch.setattr(ap, "_call_remote_api", lambda audio: "remote transcript")
+    results = ap.executor(plan)
+    assert results["results"][0]["mode"] == "remote"
+
+    aggregated = ap.result_aggregator(results)
+    assert aggregated["transcript"] == "remote transcript"
+    assert aggregated["modes"] == ["remote"]


### PR DESCRIPTION
## Summary
- add audio processing utilities that route data locally or to a remote API
- cover audio processing planner/executor with tests

## Testing
- `pytest tests/test_audio_processing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689194a58e2c832684e42297fbb36c63