### PR TITLE
Implement computer vision preprocessing pipeline and tests

### DIFF
--- a/domains/computer_vision.py
+++ b/domains/computer_vision.py
@@ -1,48 +1,97 @@
 """Utilities for computer vision tasks.
 
-These stubs demonstrate how vision-related functions could route operations
-through local models or remote APIs.
+These utilities provide a minimal but functional pipeline for handling
+vision-related operations. Images are preprocessed with :mod:`PIL`, tasks are
+planned based on simple heuristics, and the execution layer can either process
+data locally or forward it to remote APIs.
 """
 
 from __future__ import annotations
-from typing import Any, Dict
+
+from typing import Any, Dict, List
+
+import base64
+import io
+
+import requests
+from PIL import Image
 
 
-def input_processor(image: Any) -> Any:
+def input_processor(image: Any) -> Image.Image:
     """Prepare ``image`` data for model or API consumption.
 
-    Real implementations should perform tasks such as resizing, normalization,
-    and selecting whether to use local vision models or call external services.
+    The function ensures the input is a :class:`~PIL.Image.Image`, converts it
+    to RGB, and resizes it to ``224x224`` pixels.
     """
 
-    return image
+    if isinstance(image, Image.Image):
+        img = image
+    else:  # Assume a file path or file-like object
+        img = Image.open(image)
+    img = img.convert("RGB")
+    img = img.resize((224, 224))
+    return img
 
 
-def task_planner(processed_image: Any) -> Dict[str, Any]:
+def task_planner(processed_image: Image.Image) -> Dict[str, Any]:
     """Plan the sequence of vision tasks to perform.
 
-    The planner determines which components are best handled locally versus
-    those requiring API calls.
+    A very small planner that always includes a local brightness analysis. If
+    the image is fairly dark (mean pixel value below ``100``), an additional
+    remote classification step is scheduled.
     """
 
-    return {"plan": []}
+    gray = processed_image.convert("L")
+    mean = sum(gray.getdata()) / (gray.width * gray.height)
+
+    plan: List[Dict[str, Any]] = [
+        {"type": "local", "operation": "brightness", "image": gray}
+    ]
+
+    if mean < 100:  # Arbitrary heuristic for demonstration purposes
+        plan.append(
+            {
+                "type": "remote",
+                "operation": "classify",
+                "url": "https://api.example.com/vision",
+                "image": processed_image,
+            }
+        )
+
+    return {"plan": plan}
 
 
 def executor(plan: Dict[str, Any]) -> Dict[str, Any]:
     """Execute vision tasks described in ``plan``.
 
-    Each step in the plan should be run on local models or translated into API
-    requests when necessary.
+    Local tasks are performed directly with :mod:`PIL`. Remote tasks are sent to
+    a hypothetical API endpoint using :func:`requests.post`. Each executed step
+    appends its output to the returned ``results`` list.
     """
 
-    return {"results": []}
+    results: List[Dict[str, Any]] = []
+
+    for step in plan.get("plan", []):
+        if step.get("type") == "local" and step.get("operation") == "brightness":
+            img: Image.Image = step["image"]
+            mean = sum(img.getdata()) / (img.width * img.height)
+            results.append({"brightness": mean})
+        elif step.get("type") == "remote":
+            img = step["image"]
+            buffer = io.BytesIO()
+            img.save(buffer, format="PNG")
+            encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+            response = requests.post(step["url"], json={"image": encoded})
+            response.raise_for_status()
+            results.append(response.json())
+
+    return {"results": results}
 
 
 def result_aggregator(results: Dict[str, Any]) -> Dict[str, Any]:
-    """Combine results from the executed vision tasks.
+    """Combine results from the executed vision tasks."""
 
-    This function should merge outputs from various local and remote sources
-    into a unified representation.
-    """
-
-    return results
+    aggregated: Dict[str, Any] = {}
+    for item in results.get("results", []):
+        aggregated.update(item)
+    return aggregated

--- a/tests/test_computer_vision.py
+++ b/tests/test_computer_vision.py
@@ -1,0 +1,65 @@
+import pytest
+from PIL import Image
+
+from domains.computer_vision import (
+    executor,
+    input_processor,
+    result_aggregator,
+    task_planner,
+)
+
+
+def create_image(color: str, size=(50, 50)) -> Image.Image:
+    return Image.new("RGB", size, color=color)
+
+
+def test_input_processor_resizes_and_converts():
+    img = create_image("white", size=(10, 10))
+    processed = input_processor(img)
+    assert processed.size == (224, 224)
+    assert processed.mode == "RGB"
+
+
+def test_task_planner_adds_remote_for_dark_image():
+    dark = create_image("black", size=(224, 224))
+    plan_dark = task_planner(dark)
+    assert any(step["type"] == "remote" for step in plan_dark["plan"])
+
+    bright = create_image("white", size=(224, 224))
+    plan_bright = task_planner(bright)
+    assert all(step["type"] != "remote" for step in plan_bright["plan"])
+
+
+def test_executor_runs_local_and_remote(monkeypatch):
+    img = create_image("black", size=(224, 224))
+    plan = task_planner(img)
+
+    called = {}
+
+    class DummyResponse:
+        def __init__(self):
+            self.status_code = 200
+
+        def json(self):
+            return {"classification": "test"}
+
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, json=None):
+        called["url"] = url
+        called["payload"] = json
+        return DummyResponse()
+
+    monkeypatch.setattr("domains.computer_vision.requests.post", fake_post)
+    results = executor(plan)
+
+    assert results["results"][0]["brightness"] == 0.0
+    assert results["results"][1] == {"classification": "test"}
+    assert called["url"] == "https://api.example.com/vision"
+
+
+def test_result_aggregator_combines_results():
+    results = {"results": [{"a": 1}, {"b": 2}]}
+    aggregated = result_aggregator(results)
+    assert aggregated == {"a": 1, "b": 2}


### PR DESCRIPTION
## Summary
- add real image preprocessing and planning using PIL
- execute local brightness analysis and optional remote API call
- test computer vision pipeline with mocks for remote calls

## Testing
- `pytest tests/test_computer_vision.py`


------
https://chatgpt.com/codex/tasks/task_e_689194a971a4832696465fc441d8bfe5