### PR TITLE
feat: bootstrap installer dependencies

### DIFF
--- a/build_installer.ps1
+++ b/build_installer.ps1
@@ -27,19 +27,22 @@ if (Test-Path 'requirements.txt') {
     & $PythonExe -m pip install -r requirements.txt
 }
 
-# run PyInstaller
+# run PyInstaller for both architectures and bundle Python
 Write-Output "Running PyInstaller..."
-& $PythonExe -m PyInstaller --noconfirm --onefile --windowed installer/gui_installer.py --name 'WindowsAI_Installer'
-
-# copy assets
-$dist = Join-Path (Get-Location) 'dist'
 $resources = @('install','plugins','assets','config','control_center','automation','windows_ai')
-foreach ($res in $resources) {
-    if (Test-Path $res) {
-        Copy-Item $res -Destination (Join-Path $dist $res) -Recurse -Force
+$arches = @('x64','x86')
+foreach ($arch in $arches) {
+    $name = "WindowsAI_Installer_$arch"
+    $dist = Join-Path (Get-Location) "dist\$arch"
+    & $PythonExe -m PyInstaller --noconfirm --onefile --windowed installer/gui_installer.py `
+        --name $name --distpath $dist --python-option embed --target-arch $arch
+    foreach ($res in $resources) {
+        if (Test-Path $res) {
+            Copy-Item $res -Destination (Join-Path $dist $res) -Recurse -Force
+        }
     }
+    Write-Output "Installer built at $dist\$name.exe"
 }
 
-Write-Output "Installer built at dist\WindowsAI_Installer.exe"
 Write-Output "Running the installer will automatically execute install\install.ps1"
 Write-Output "with admin rights to register services."

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,5 +1,42 @@
 Write-Host "Installing Windows AI services..."
 
+function Ensure-Tool {
+    param(
+        [string]$Command,
+        [scriptblock]$Installer
+    )
+    if (-not (Get-Command $Command -ErrorAction SilentlyContinue)) {
+        Write-Host "$Command not found, attempting download..."
+        & $Installer
+    }
+}
+
+Ensure-Tool 'nssm.exe' {
+    $url = 'https://nssm.cc/release/nssm-2.24.zip'
+    $zip = Join-Path $env:TEMP 'nssm.zip'
+    Invoke-WebRequest $url -OutFile $zip
+    $dir = Join-Path $env:ProgramData 'nssm'
+    Expand-Archive $zip -DestinationPath $dir -Force
+    $nssmExe = Get-ChildItem $dir -Recurse -Filter nssm.exe | Select-Object -First 1
+    if ($nssmExe) {
+        $env:PATH = "$($nssmExe.Directory.FullName);$env:PATH"
+    }
+}
+
+Ensure-Tool 'mkcert' {
+    $url = 'https://github.com/FiloSottile/mkcert/releases/latest/download/mkcert.exe'
+    $exe = Join-Path $env:ProgramData 'mkcert.exe'
+    Invoke-WebRequest $url -OutFile $exe
+    $env:PATH = "$env:ProgramData;$env:PATH"
+}
+
+Ensure-Tool 'node' {
+    $url = 'https://nodejs.org/dist/v20.11.0/node-v20.11.0-x64.msi'
+    $msi = Join-Path $env:TEMP 'node.msi'
+    Invoke-WebRequest $url -OutFile $msi
+    Start-Process msiexec.exe -ArgumentList '/i',$msi,'/quiet','/norestart' -Wait
+}
+
 # Start a new snapshot so we can rollback these actions later
 if (Get-Command python -ErrorAction SilentlyContinue) {
     python -m installer.snapshot create

--- a/tests/installer/test_full_install.py
+++ b/tests/installer/test_full_install.py
@@ -1,0 +1,32 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="PowerShell not available")
+def test_installer_downloads_prerequisites(tmp_path):
+    script = Path(__file__).resolve().parents[2] / "install" / "install.ps1"
+    log = tmp_path / "log.txt"
+
+    ps = f"""
+$ErrorActionPreference='Stop'
+$Log = '{log}'
+function Invoke-WebRequest {{ param($Uri,$OutFile) Add-Content -Path $Log -Value $Uri; New-Item -ItemType File -Path $OutFile -Force | Out-Null }}
+function Expand-Archive {{ param($Path,$DestinationPath,[switch]$Force) Add-Content -Path $Log -Value "EXPAND:$Path"; New-Item -ItemType Directory -Path $DestinationPath -Force | Out-Null; New-Item -ItemType File -Path (Join-Path $DestinationPath 'nssm.exe') -Force | Out-Null }}
+function Start-Process {{ param($FilePath,$ArgumentList,[switch]$Wait) Add-Content -Path $Log -Value "START:$FilePath" }}
+function nssm {{ param($Action,$Name,$Exe,$Args) Add-Content -Path $Log -Value "NSSM:$Action" }}
+function mkcert {{ param($Arg) Add-Content -Path $Log -Value "MKCERT:$Arg" }}
+function node {{ param($A,$B,$C) Add-Content -Path $Log -Value "NODE:$A" }}
+$env:PATH=''
+$env:ProgramData='{tmp_path}'
+$env:TEMP='{tmp_path}'
+. '{script}'
+"""
+
+    subprocess.run(["pwsh", "-NoLogo", "-NoProfile", "-Command", ps], check=True)
+    lines = log.read_text().splitlines()
+    assert any("nssm.cc" in line for line in lines)
+    assert any("mkcert" in line for line in lines)
+    assert any("nodejs.org" in line for line in lines)


### PR DESCRIPTION
## Summary
- build PyInstaller-based installers for x86 and x64, bundling an embedded Python runtime
- auto-install missing tools (nssm, mkcert, Node) during installer execution
- test installer behavior when prerequisites are absent

## Testing
- `pytest tests/installer/test_full_install.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689196e2b70083269be764a6f3e7f339