### PR TITLE
feat(installer): add log level env var

### DIFF
--- a/docs/Smart-Installer.md
+++ b/docs/Smart-Installer.md
@@ -99,6 +99,18 @@ subprocess.check_call([sys.executable, "-m", "pip", "install", "transformers"])
 
 This pseudocode only scratches the surface but illustrates how the installer might check hardware details and install dependencies programmatically.
 
+## Logging
+
+The installer records errors to ``%USERPROFILE%\AI\Logs\installer.log``.  Set
+the ``WINDOWS_AI_LOG_LEVEL`` environment variable (for example ``DEBUG`` or
+``INFO``) to print messages to the console while running:
+
+```
+WINDOWS_AI_LOG_LEVEL=DEBUG python -m installer.cli --install-all
+```
+
+Only when the configured level is below ``ERROR`` are console messages shown.
+
 ## Troubleshooting
 
 - **GUI fails to start** – Ensure ``tkinter`` is installed and that you are not

--- a/installer/logging_config.py
+++ b/installer/logging_config.py
@@ -18,7 +18,21 @@ _formatter = logging.Formatter(
     "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
 )
 _file_handler.setFormatter(_formatter)
-logging.basicConfig(level=logging.INFO, handlers=[_file_handler])
+
+# Configure the root logger level via environment variable.  When the level is
+# set below ``ERROR`` a console handler is added so messages are visible in the
+# terminal as well.  If the provided level is not recognised it defaults to
+# ``ERROR``.
+_level_name = os.getenv("WINDOWS_AI_LOG_LEVEL", "ERROR").upper()
+_root_level = getattr(logging, _level_name, logging.ERROR)
+_handlers = [_file_handler]
+if _root_level < logging.ERROR:
+    _console_handler = logging.StreamHandler()
+    _console_handler.setLevel(_root_level)
+    _console_handler.setFormatter(_formatter)
+    _handlers.append(_console_handler)
+
+logging.basicConfig(level=_root_level, handlers=_handlers)
 
 
 def get_logger(name: str) -> logging.Logger:


### PR DESCRIPTION
## Summary
- allow setting log level via `WINDOWS_AI_LOG_LEVEL`
- show console logs when level below ERROR
- document log configuration in Smart Installer guide

## Testing
- `pytest tests/test_api_keys.py -q`
- `WINDOWS_AI_LOG_LEVEL=DEBUG python - <<'PY'` (manual check)

------
https://chatgpt.com/codex/tasks/task_e_68919a19f618832696000eb09c3d6fc5