### PR TITLE
refactor: organize installer model imports

### DIFF
--- a/installer/models.py
+++ b/installer/models.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, List
-import urllib.request
 
 
 # ``ModelInfo`` captures metadata about downloadable model files.  Instead of


### PR DESCRIPTION
## Summary
- organize installer model imports and ensure required modules are declared

## Testing
- `python - <<'PY'
from installer.models import list_models
print(list_models())
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68919a20d27c8326bbeaf303d0163ab7