### PR TITLE
feat: allow removing virtual environments

### DIFF
--- a/installer/env.py
+++ b/installer/env.py
@@ -97,6 +97,29 @@ def load_recorded_envs() -> dict[str, str]:
         return {}
 
 
+def remove_env(name: str) -> None:
+    """Remove the environment named ``name`` and update the record file."""
+
+    env_path = BASE_DIR / name
+    if env_path.exists():
+        shutil.rmtree(env_path, ignore_errors=True)
+
+    if not ENV_RECORD_FILE.exists():
+        return
+
+    try:
+        data = json.loads(ENV_RECORD_FILE.read_text())
+    except Exception:
+        data = {}
+
+    if name in data:
+        del data[name]
+        if data:
+            ENV_RECORD_FILE.write_text(json.dumps(data, indent=2))
+        else:
+            ENV_RECORD_FILE.unlink()
+
+
 __all__ = [
     "CONFIG_DIR",
     "BASE_DIR",
@@ -104,5 +127,6 @@ __all__ = [
     "create_env",
     "python_executable",
     "install_packages",
+    "remove_env",
     "load_recorded_envs",
 ]

--- a/tests/test_env_remove.py
+++ b/tests/test_env_remove.py
@@ -1,0 +1,19 @@
+import json
+from installer import env
+
+
+def test_remove_env_deletes_directory_and_record(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    monkeypatch.setattr(env, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(env, "BASE_DIR", config_dir / "venvs")
+    monkeypatch.setattr(env, "ENV_RECORD_FILE", config_dir / "envs.json")
+
+    env_dir = env.BASE_DIR / "sample"
+    env_dir.mkdir(parents=True)
+
+    env.ENV_RECORD_FILE.write_text(json.dumps({"sample": str(env_dir)}))
+
+    env.remove_env("sample")
+
+    assert not env_dir.exists()
+    assert not env.ENV_RECORD_FILE.exists()


### PR DESCRIPTION
## Summary
- add `remove_env` utility to delete environments and clean record file
- expose `remove_env` in `installer.env`
- test environment removal

## Testing
- `pytest tests/test_env_remove.py tests/test_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68919a34bb808326b298d67e624e5fce