### PR TITLE
Handle env creation subprocess failures

### DIFF
--- a/installer/env.py
+++ b/installer/env.py
@@ -11,6 +11,7 @@ import json
 import os
 import subprocess
 import venv
+import logging
 from pathlib import Path
 from typing import Iterable
 import shutil
@@ -20,6 +21,8 @@ CONFIG_DIR = Path.home() / ".windows_ai"
 BASE_DIR = CONFIG_DIR / "venvs"
 ENV_RECORD_FILE = CONFIG_DIR / "envs.json"
 BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+logger = logging.getLogger(__name__)
 
 
 def _use_conda() -> bool:
@@ -63,7 +66,14 @@ def create_env(name: str, backend: str | None = None) -> Path:
     backend = backend or ("conda" if _use_conda() else "venv")
     if not env_path.exists():
         if backend == "conda":
-            subprocess.check_call(["conda", "create", "-y", "-p", str(env_path), "python"])
+            cmd = ["conda", "create", "-y", "-p", str(env_path), "python"]
+            try:
+                subprocess.check_call(cmd, stderr=subprocess.PIPE, text=True)
+            except subprocess.CalledProcessError as exc:
+                logger.error("Command %s failed with stderr: %s", exc.cmd, exc.stderr)
+                raise RuntimeError(
+                    f"Failed to create environment '{name}' using conda"
+                ) from exc
         else:
             venv.EnvBuilder(with_pip=True).create(env_path)
     _record_env_path(name, env_path)

--- a/tests/test_env_failures.py
+++ b/tests/test_env_failures.py
@@ -1,0 +1,26 @@
+import logging
+import subprocess
+import pytest
+
+from installer import env
+
+def test_conda_env_creation_failure_logs_and_raises(tmp_path, monkeypatch, caplog):
+    config_dir = tmp_path / "config"
+    monkeypatch.setattr(env, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(env, "BASE_DIR", config_dir / "venvs")
+    monkeypatch.setattr(env, "ENV_RECORD_FILE", config_dir / "envs.json")
+    monkeypatch.setattr(env, "_use_conda", lambda: True)
+
+    def fail(cmd, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd, stderr="boom")
+
+    monkeypatch.setattr(subprocess, "check_call", fail)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as excinfo:
+            env.create_env("broken")
+
+    expected_cmd = ["conda", "create", "-y", "-p", str(env.BASE_DIR / "broken"), "python"]
+    assert str(expected_cmd) in caplog.text
+    assert "boom" in caplog.text
+    assert "Failed to create environment" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- log conda environment creation failures including command and stderr
- raise a descriptive RuntimeError when env creation fails
- test environment failure handling with a mocked subprocess

## Testing
- `pytest tests/test_env.py tests/test_env_failures.py`


------
https://chatgpt.com/codex/tasks/task_e_68919a3eb9088326bfafbf85d590c6e3