### PR TITLE
Handle extras and markers in env setup requirements

### DIFF
--- a/installer/env_setup.py
+++ b/installer/env_setup.py
@@ -9,7 +9,8 @@ conflicts can be automatically resolved by selecting the highest pinned version.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable, Tuple, Dict, List
+from dataclasses import dataclass
+from typing import Iterable, Tuple, Dict, List, Iterable as Iter, Set
 
 from packaging.requirements import Requirement
 from packaging.version import Version
@@ -18,15 +19,37 @@ from packaging.specifiers import SpecifierSet
 from installer import env, plugins
 
 
-def _parse_requirements(requirements: Iterable[str]) -> Dict[str, List[Requirement]]:
-    """Group requirement strings by normalized package name."""
+@dataclass
+class ParsedRequirement:
+    extras: Set[str]
+    specifier: SpecifierSet
+    marker: str | None
+    original: str
 
-    grouped: Dict[str, List[Requirement]] = {}
+
+def _parse_requirements(requirements: Iterable[str]) -> Dict[str, List[ParsedRequirement]]:
+    """Group requirement strings by normalized package name, preserving extras and markers."""
+
+    grouped: Dict[str, List[ParsedRequirement]] = {}
     for req_str in requirements:
         req = Requirement(req_str)
         name = req.name.lower()
-        grouped.setdefault(name, []).append(req)
+        grouped.setdefault(name, []).append(
+            ParsedRequirement(set(req.extras), req.specifier, str(req.marker) if req.marker else None, req_str)
+        )
     return grouped
+
+
+def _merge_markers(markers: Iter[str | None]) -> str | None:
+    markers = list(markers)
+    if any(m is None for m in markers):
+        return None
+    unique = sorted({m for m in markers if m})
+    if not unique:
+        return None
+    if len(unique) == 1:
+        return unique[0]
+    return " or ".join(f"({m})" if " or " in m or " and " in m else m for m in unique)
 
 
 def resolve_conflicts(requirements: Iterable[str], auto_resolve: bool = True) -> Tuple[List[str], Dict[str, List[str]]]:
@@ -47,24 +70,30 @@ def resolve_conflicts(requirements: Iterable[str], auto_resolve: bool = True) ->
     conflicts: Dict[str, List[str]] = {}
 
     for name, reqs in grouped.items():
-        if len(reqs) == 1:
-            resolved.append(str(reqs[0]))
-            continue
+        extras = set().union(*(r.extras for r in reqs))
+        extras_str = f"[{','.join(sorted(extras))}]" if extras else ""
 
         pinned = {spec.version for r in reqs for spec in r.specifier if spec.operator in {"==", "==="}}
         if len(pinned) > 1:
-            # conflicting explicit versions
-            conflicts[name] = [str(r) for r in reqs]
+            conflicts[name] = [r.original for r in reqs]
             if auto_resolve:
                 chosen = max(pinned, key=Version)
-                resolved.append(f"{name}=={chosen}")
+                marker = _merge_markers(r.marker for r in reqs)
+                req_str = f"{name}{extras_str}=={chosen}"
+                if marker:
+                    req_str += f"; {marker}"
+                resolved.append(req_str)
             continue
 
-        # combine remaining specifiers (if any)
         spec: SpecifierSet | None = None
         for r in reqs:
             spec = r.specifier if spec is None else spec & r.specifier
-        resolved.append(f"{name}{spec}")
+        spec_str = str(spec) if spec and str(spec) else ""
+        marker = _merge_markers(r.marker for r in reqs)
+        req_str = f"{name}{extras_str}{spec_str}"
+        if marker:
+            req_str += f"; {marker}"
+        resolved.append(req_str)
 
     return resolved, conflicts
 

--- a/tests/test_env_setup_requirements.py
+++ b/tests/test_env_setup_requirements.py
@@ -1,0 +1,21 @@
+import pytest
+from installer import env_setup
+
+
+def test_parse_requirements_extras_markers():
+    grouped = env_setup._parse_requirements(["demo[extra1,extra2]>=1; sys_platform=='win32'"])
+    parsed = grouped["demo"][0]
+    assert parsed.extras == {"extra1", "extra2"}
+    assert str(parsed.specifier) == ">=1"
+    assert parsed.marker == 'sys_platform == "win32"'
+
+
+def test_resolve_conflicts_merges_extras_and_markers():
+    reqs = [
+        "demo[one]; sys_platform=='win32'",
+        "demo[two]; sys_platform=='linux'",
+    ]
+    packages, conflicts = env_setup.resolve_conflicts(reqs)
+    assert conflicts == {}
+    expected_marker = 'sys_platform == "linux" or sys_platform == "win32"'
+    assert packages == [f"demo[one,two]; {expected_marker}"]


### PR DESCRIPTION
## Summary
- parse requirement strings while preserving extras and environment markers
- merge extras and compatible markers when resolving dependency conflicts
- add tests for requirement parsing and marker merging

## Testing
- `pytest tests/test_env_setup_requirements.py tests/test_env_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68919a42f4d083269876e19112e357d7