### PR TITLE
Add non-interactive installer flag

### DIFF
--- a/BUILD_WINDOWS_INSTALLER.md
+++ b/BUILD_WINDOWS_INSTALLER.md
@@ -48,6 +48,16 @@ Optional but recommended:
 To remove integrations, use `install\uninstall.ps1` and
 `install\context_menu_remove.reg`.
 
+## Non-interactive CLI mode
+
+The prototype installer exposes a Python CLI in `installer/cli.py`. When
+automating setup, invoke it with the `--non-interactive` (or `--yes`) flag to
+skip API key prompts and decline launching the Control Center GUI:
+
+```bash
+python -m installer.cli --non-interactive
+```
+
 ## Updating
 
 When repository changes occur, rerun the build script to generate an updated

--- a/installer/cli.py
+++ b/installer/cli.py
@@ -58,6 +58,17 @@ def main() -> None:
         action="store_true",
         help="install plugin dependencies in their own environment",
     )
+    parser.add_argument(
+        "-y",
+        "--yes",
+        "--non-interactive",
+        dest="yes",
+        action="store_true",
+        help=(
+            "run without interactive prompts; defaults API-key actions and declines GUI "
+            "launch"
+        ),
+    )
     args = parser.parse_args()
 
     info = system_info.detect_system()
@@ -90,13 +101,16 @@ def main() -> None:
         performed_action = True
 
     if not performed_action:
-        try:
-            choice = input(
-                "API key options: [l]ist, [d]elete, [a]dd or [n]one? "
-            ).strip().lower()
-        except Exception:
-            logger.exception("Failed to read API key choice")
+        if args.yes:
             choice = "n"
+        else:
+            try:
+                choice = input(
+                    "API key options: [l]ist, [d]elete, [a]dd or [n]one? "
+                ).strip().lower()
+            except Exception:
+                logger.exception("Failed to read API key choice")
+                choice = "n"
 
         if choice == "l":
             keys = api_keys.list_keys()
@@ -126,11 +140,14 @@ def main() -> None:
         install_all()
 
     # Offer to launch the Control Center after setup completes
-    try:
-        launch = input("Launch Control Center GUI now? [y/N] ").strip().lower()
-    except Exception:
-        logger.exception("Failed to read launch choice")
+    if args.yes:
         launch = "n"
+    else:
+        try:
+            launch = input("Launch Control Center GUI now? [y/N] ").strip().lower()
+        except Exception:
+            logger.exception("Failed to read launch choice")
+            launch = "n"
     if launch in {"y", "yes"}:
         try:
             from control_center.gui import main as launch_gui

--- a/tests/test_installer_cli.py
+++ b/tests/test_installer_cli.py
@@ -1,0 +1,19 @@
+import builtins
+import sys
+from installer import cli
+
+
+def test_non_interactive_skips_prompts(monkeypatch, capsys):
+    """Ensure --non-interactive avoids any input prompts."""
+    monkeypatch.setattr(cli.system_info, "detect_system", lambda: {})
+
+    def fail_input(*args, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError("input called")
+
+    monkeypatch.setattr(builtins, "input", fail_input)
+    monkeypatch.setattr(sys, "argv", ["prog", "--non-interactive"])
+
+    cli.main()
+    out = capsys.readouterr().out
+    assert "API key options" not in out
+    assert "Launch Control Center GUI now?" not in out


### PR DESCRIPTION
## Summary
- Add `--yes`/`--non-interactive` flag to installer CLI to skip prompts and GUI launch
- Document non-interactive CLI usage in build instructions
- Add test ensuring the flag suppresses all prompts

## Testing
- `pytest tests/test_installer_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68919a4837948326a0066409fa9d8b6f