### PR TITLE
feat: prompt for admin rights in GUI installer

### DIFF
--- a/installer/gui_installer.py
+++ b/installer/gui_installer.py
@@ -8,6 +8,7 @@ it can run in constrained environments.
 from __future__ import annotations
 
 import os
+import ctypes
 import subprocess
 import sys
 import threading
@@ -230,6 +231,15 @@ class GUIInstaller:
         ttk.Button(top, text="Apply", command=apply_config).pack(pady=5)
 
     # --- Finalization -----------------------------------------------------
+    def _is_admin(self) -> bool:
+        """Return True if running with administrator rights."""
+
+        try:
+            return bool(ctypes.windll.shell32.IsUserAnAdmin())
+        except Exception:  # pragma: no cover - platform dependent
+            # If the API is unavailable (e.g. non-Windows), assume admin.
+            return True
+
     def _run_install_script(self) -> None:
         base = (
             Path(sys.executable).resolve().parent
@@ -255,6 +265,18 @@ class GUIInstaller:
         self.progress.start()
         self.root.update()
         try:
+            if not self._is_admin():
+                self.progress.stop()
+                self.progress.config(mode="determinate", value=0)
+                if messagebox.askyesno(
+                    "Installer",
+                    "Administrator rights required. Relaunch with elevation?",
+                ):
+                    params = " ".join(f'"{arg}"' for arg in sys.argv)
+                    ctypes.windll.shell32.ShellExecuteW(
+                        None, "runas", sys.executable, params, None, 1
+                    )
+                return
             self._run_install_script()
             messagebox.showinfo("Installer", "Setup complete")
         except Exception as exc:  # pragma: no cover - environment specific

--- a/tests/test_gui_installer.py
+++ b/tests/test_gui_installer.py
@@ -101,3 +101,64 @@ def test_advanced_configuration(monkeypatch, tk_root):
     assert gui.backend == "remote"
     text = gui.info.get("1.0", tk.END)
     assert "Recommended backend: remote" in text
+
+
+def test_finalize_runs_script_when_admin(monkeypatch, tk_root):
+    from installer.gui_installer import GUIInstaller
+
+    gui = GUIInstaller(root=tk_root)
+
+    monkeypatch.setattr(GUIInstaller, "_is_admin", lambda self: True)
+
+    called = {}
+
+    def fake_run(self):
+        called["ran"] = True
+
+    monkeypatch.setattr(GUIInstaller, "_run_install_script", fake_run)
+    monkeypatch.setattr(
+        "installer.gui_installer.messagebox.showinfo", lambda *a, **k: None
+    )
+
+    gui._finalize()
+    tk_root.destroy = lambda: None
+
+    assert called.get("ran") is True
+
+
+def test_finalize_prompts_for_elevation(monkeypatch, tk_root):
+    from installer.gui_installer import GUIInstaller
+    import types
+
+    gui = GUIInstaller(root=tk_root)
+
+    monkeypatch.setattr(GUIInstaller, "_is_admin", lambda self: False)
+
+    prompts = {}
+
+    def fake_askyesno(title, msg):
+        prompts["msg"] = msg
+        return True
+
+    monkeypatch.setattr("installer.gui_installer.messagebox.askyesno", fake_askyesno)
+
+    shell_calls = {}
+
+    def fake_shell_executeW(*args):
+        shell_calls["args"] = args
+        return 0
+
+    shell32 = types.SimpleNamespace(ShellExecuteW=fake_shell_executeW)
+    windll = types.SimpleNamespace(shell32=shell32)
+    monkeypatch.setattr("installer.gui_installer.ctypes", "windll", windll)
+
+    def fail_run(self):
+        raise AssertionError("Should not run install script")
+
+    monkeypatch.setattr(GUIInstaller, "_run_install_script", fail_run)
+
+    gui._finalize()
+    tk_root.destroy = lambda: None
+
+    assert "msg" in prompts
+    assert "args" in shell_calls


### PR DESCRIPTION
## Summary
- check for admin privileges before running install script
- offer to relaunch the installer with elevation when needed
- add tests that mock the admin check for both elevated and non-elevated scenarios

## Testing
- `pytest tests/test_gui_installer.py::test_finalize_runs_script_when_admin tests/test_gui_installer.py::test_finalize_prompts_for_elevation -q`


------
https://chatgpt.com/codex/tasks/task_e_68919efc423483269aac48197ba3477b