### PR TITLE
feat(installer): allow plugin catalog override

### DIFF
--- a/docs/Smart-Installer.md
+++ b/docs/Smart-Installer.md
@@ -63,6 +63,12 @@ python -m installer.cli --install-all
 
 The GUI's **Install All** button performs the same operation.
 
+### Custom Plugin Catalog
+
+The plugin manager reads its catalog from ``plugins/catalog.json`` by default.
+Set the ``WINDOWS_AI_PLUGIN_CATALOG`` environment variable to override this
+path when testing or using a custom catalog.
+
 ## Configuration Examples
 
 A plugin declares the packages it needs in a small Python module. Place the file

--- a/installer/plugins/manager.py
+++ b/installer/plugins/manager.py
@@ -7,13 +7,15 @@ will invoke the associated installation commands.
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, List
 
-CATALOG_PATH = Path(__file__).resolve().parents[2] / "plugins" / "catalog.json"
+DEFAULT_CATALOG_PATH = Path(__file__).resolve().parents[2] / "plugins" / "catalog.json"
+CATALOG_PATH = Path(os.environ.get("WINDOWS_AI_PLUGIN_CATALOG", DEFAULT_CATALOG_PATH))
 
 
 @dataclass

--- a/tests/test_installer_plugin_manager.py
+++ b/tests/test_installer_plugin_manager.py
@@ -1,0 +1,18 @@
+import importlib
+import json
+
+
+def test_catalog_path_env_override(tmp_path, monkeypatch):
+    catalog = tmp_path / "catalog.json"
+    catalog.write_text(
+        json.dumps({"plugins": [{"name": "Alt", "description": "", "command": "echo hi"}]})
+    )
+
+    monkeypatch.setenv("WINDOWS_AI_PLUGIN_CATALOG", str(catalog))
+
+    from installer.plugins import manager as manager_module
+
+    importlib.reload(manager_module)
+
+    plugins = manager_module.load_catalog()
+    assert [p.name for p in plugins] == ["Alt"]


### PR DESCRIPTION
## Summary
- allow overriding plugin catalog via `WINDOWS_AI_PLUGIN_CATALOG`
- document plugin catalog override for Smart Installer
- add unit test for catalog path override

## Testing
- `pytest`
- `pytest tests/test_installer_plugin_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a435597c8326b2f5700018aba6db