### PR TITLE
feat: sign installer with optional certificate

### DIFF
--- a/BUILD_WINDOWS_INSTALLER.md
+++ b/BUILD_WINDOWS_INSTALLER.md
@@ -23,7 +23,7 @@ Optional but recommended:
 2. Run the build script:
 
    ```powershell
-   ./build_installer.ps1
+   ./build_installer.ps1 [-CertPath path\to\cert.pfx -TimestampServer https://timestamp.server]
    ```
 
    The script will:
@@ -32,8 +32,22 @@ Optional but recommended:
    - Package `installer/gui_installer.py` into `dist/WindowsAI_Installer.exe`
    - Copy runtime assets (`install`, `plugins`, `assets`, `config`, `control_center`,
      `automation`, `windows_ai`) into the `dist/` folder alongside the executable
+   - Optionally sign `dist\WindowsAI_Installer.exe` with `SignTool.exe` if `-CertPath`
+     and `-TimestampServer` are provided
 
 3. After the script completes, the executable is located at `dist/WindowsAI_Installer.exe`.
+
+### Code Signing (optional)
+
+To distribute a signed installer, supply a code signing certificate and a timestamp
+server when running the build script. `SignTool.exe` from the Windows SDK must be
+available in your `PATH`.
+
+```powershell
+./build_installer.ps1 -CertPath C:\path\to\cert.pfx -TimestampServer https://timestamp.digicert.com
+```
+
+The script will invoke `SignTool.exe` to sign the generated `WindowsAI_Installer.exe`.
 
 ## Testing the Installer
 

--- a/build_installer.ps1
+++ b/build_installer.ps1
@@ -2,7 +2,9 @@
 # Run from repository root on Windows
 
 param(
-    [string]$PythonExe = "python"
+    [string]$PythonExe = "python",
+    [string]$CertPath = "",
+    [string]$TimestampServer = ""
 )
 
 $ErrorActionPreference = 'Stop'
@@ -56,5 +58,18 @@ foreach ($arch in $architectures) {
     Write-Output "Installer built at $dist\WindowsAI_Installer_$arch.exe"
 }
 
-Write-Output "Running the installers will automatically execute install\install.ps1"
+$installerExe = Join-Path $dist 'WindowsAI_Installer.exe'
+if ($CertPath -and $TimestampServer) {
+    if (Test-Path $CertPath) {
+        Write-Output "Signing installer..."
+        & "SignTool.exe" sign /fd SHA256 /f $CertPath /tr $TimestampServer /td SHA256 $installerExe
+    } else {
+        Write-Output "Certificate not found at $CertPath. Skipping signing."
+    }
+} else {
+    Write-Output "CertPath or TimestampServer not provided. Skipping signing."
+}
+
+Write-Output "Installer built at dist\WindowsAI_Installer.exe"
+Write-Output "Running the installer will automatically execute install\install.ps1"
 Write-Output "with admin rights to register services."


### PR DESCRIPTION
## Summary
- allow `build_installer.ps1` to sign the built installer using a provided certificate and timestamp server
- document code-signing parameters and usage in `BUILD_WINDOWS_INSTALLER.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891a43b3f8483268c3ba6f29315500a