### PR TITLE
Add localized installer guides and GUI selector

### DIFF
--- a/BUILD_WINDOWS_INSTALLER.md
+++ b/BUILD_WINDOWS_INSTALLER.md
@@ -3,6 +3,9 @@
 This document explains how to produce a single `WindowsAI_Installer.exe` that bundles
 this repository and launches the Tkinter-based installer GUI.
 
+Quick-start guides for using the installer are available in `docs/README.en.md`
+(English) and `docs/README.es.md` (Español).
+
 ## Prerequisites
 
 - Windows 10 or later

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -1,0 +1,12 @@
+# Windows AI Installer Quick Start
+
+This guide explains how to use the graphical installer that ships with Windows AI.
+
+1. Double-click `WindowsAI_Installer.exe`.
+2. In the installer window you can:
+   - Detect system information and recommended backend.
+   - Add or check API keys.
+   - Install required plugin and tool dependencies.
+3. Close the installer window to continue with the scripted setup that registers services and other integrations.
+
+For build instructions see [BUILD_WINDOWS_INSTALLER.md](../BUILD_WINDOWS_INSTALLER.md).

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,0 +1,12 @@
+# Inicio rápido del instalador de Windows AI
+
+Esta guía explica cómo usar el instalador gráfico incluido con Windows AI.
+
+1. Ejecute `WindowsAI_Installer.exe`.
+2. En la ventana del instalador puede:
+   - Detectar la información del sistema y el backend recomendado.
+   - Añadir o comprobar claves de API.
+   - Instalar las dependencias necesarias de complementos y herramientas.
+3. Cierre la ventana del instalador para continuar con la configuración automática que registra servicios y otras integraciones.
+
+Para instrucciones de compilación consulte [BUILD_WINDOWS_INSTALLER.md](../BUILD_WINDOWS_INSTALLER.md).

--- a/installer/gui_installer.py
+++ b/installer/gui_installer.py
@@ -14,6 +14,7 @@ import threading
 from pathlib import Path
 import tkinter as tk
 from tkinter import messagebox, simpledialog, ttk
+import webbrowser
 
 if __package__ is None or __package__ == "":  # pragma: no cover - script entry
     sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -68,6 +69,26 @@ class GUIInstaller:
         self.progress = ttk.Progressbar(self.root, length=300, mode="determinate")
         self.progress.pack(padx=10, pady=10)
         self.root.protocol("WM_DELETE_WINDOW", self._finalize)
+
+        # guide selector
+        guide_frame = tk.Frame(self.root)
+        guide_frame.pack(padx=10, pady=5)
+        ttk.Label(guide_frame, text="Guide:").pack(side=tk.LEFT)
+        self._lang_var = tk.StringVar(value="English")
+        self._guide_paths = {
+            "English": Path(__file__).resolve().parents[1] / "docs" / "README.en.md",
+            "Español": Path(__file__).resolve().parents[1] / "docs" / "README.es.md",
+        }
+        ttk.Combobox(
+            guide_frame,
+            textvariable=self._lang_var,
+            values=list(self._guide_paths.keys()),
+            state="readonly",
+            width=10,
+        ).pack(side=tk.LEFT, padx=5)
+        ttk.Button(guide_frame, text="Open", command=self.open_guide).pack(
+            side=tk.LEFT
+        )
 
     # --- System detection -------------------------------------------------
     def detect_system(self) -> None:
@@ -228,6 +249,16 @@ class GUIInstaller:
             top.destroy()
 
         ttk.Button(top, text="Apply", command=apply_config).pack(pady=5)
+
+    # --- Guide handling ---------------------------------------------------
+    def open_guide(self) -> None:
+        """Open the quick-start guide in the selected language."""
+
+        path = self._guide_paths.get(self._lang_var.get())
+        if path and path.exists():
+            webbrowser.open(path.as_uri())
+        else:
+            messagebox.showerror("Guide", "Guide not found")
 
     # --- Finalization -----------------------------------------------------
     def _run_install_script(self) -> None:


### PR DESCRIPTION
## Summary
- add English and Spanish quick-start guides for the Windows AI installer
- surface quick-start docs in BUILD_WINDOWS_INSTALLER.md
- add language selector in GUI installer to open the relevant guide

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a4446b888326bb539f5a809dab21