### PR TITLE
Build installers for x86 and x64

### DIFF
--- a/.github/workflows/ci-windows-powershell.yml
+++ b/.github/workflows/ci-windows-powershell.yml
@@ -39,3 +39,10 @@ jobs:
 
       - name: Run tests
         run: pytest -q
+
+      - name: Build installers
+        shell: pwsh
+        run: |
+          ./build_installer.ps1
+          if (-not (Test-Path 'dist_x86/WindowsAI_Installer_x86.exe')) { throw 'x86 build failed' }
+          if (-not (Test-Path 'dist_x64/WindowsAI_Installer_x64.exe')) { throw 'x64 build failed' }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,34 @@ on:
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
       - run: npm ci || npm i
       - run: npx semantic-release || echo "semantic-release not configured"
+
+  build-windows-installer:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Build installers
+        shell: pwsh
+        run: ./build_installer.ps1
+      - name: Compress x86
+        shell: pwsh
+        run: Compress-Archive -Path dist_x86/* -DestinationPath windows_ai_installer_x86.zip
+      - name: Compress x64
+        shell: pwsh
+        run: Compress-Archive -Path dist_x64/* -DestinationPath windows_ai_installer_x64.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows_ai_installer_x86
+          path: windows_ai_installer_x86.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows_ai_installer_x64
+          path: windows_ai_installer_x64.zip

--- a/build_installer.ps1
+++ b/build_installer.ps1
@@ -27,22 +27,34 @@ if (Test-Path 'requirements.txt') {
     & $PythonExe -m pip install -r requirements.txt
 }
 
-# run PyInstaller for both architectures and bundle Python
-Write-Output "Running PyInstaller..."
+# run PyInstaller for both architectures
+$architectures = @('x86', 'x64')
 $resources = @('install','plugins','assets','config','control_center','automation','windows_ai')
-$arches = @('x64','x86')
-foreach ($arch in $arches) {
-    $name = "WindowsAI_Installer_$arch"
-    $dist = Join-Path (Get-Location) "dist\$arch"
+
+foreach ($arch in $architectures) {
+    Write-Output "Running PyInstaller for $arch..."
+
+    $dist = Join-Path (Get-Location) "dist_$arch"
+    $build = Join-Path (Get-Location) "build_$arch"
+
+    if (Test-Path $dist) { Remove-Item $dist -Recurse -Force }
+    if (Test-Path $build) { Remove-Item $build -Recurse -Force }
+
     & $PythonExe -m PyInstaller --noconfirm --onefile --windowed installer/gui_installer.py `
-        --name $name --distpath $dist --python-option embed --target-arch $arch
+        --name "WindowsAI_Installer_$arch" `
+        --distpath $dist `
+        --workpath $build `
+        --specpath $build `
+        --target-arch $arch
+
     foreach ($res in $resources) {
         if (Test-Path $res) {
             Copy-Item $res -Destination (Join-Path $dist $res) -Recurse -Force
         }
     }
-    Write-Output "Installer built at $dist\$name.exe"
+
+    Write-Output "Installer built at $dist\WindowsAI_Installer_$arch.exe"
 }
 
-Write-Output "Running the installer will automatically execute install\install.ps1"
+Write-Output "Running the installers will automatically execute install\install.ps1"
 Write-Output "with admin rights to register services."


### PR DESCRIPTION
## Summary
- Run PyInstaller twice in `build_installer.ps1` for x86 and x64 outputs.
- Add Windows release job to package both architectures and upload artifacts.
- Extend CI workflow to build installers for both architectures.

## Testing
- `pytest -q`
- `pwsh -NoProfile -File build_installer.ps1` *(fails: command not found: pwsh)*

------
https://chatgpt.com/codex/tasks/task_e_6891a43fb8d48326af60ca73e58a6117