### PR TITLE
fix: ensure husky and docs for local setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ AI/Logs/
 
 # Virtual environments
 .venv/
+venv/
 
 # Installer secrets
 installer/keys.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,25 @@ This repository includes a preconfigured development container for VS Code.
 3. VS Code will build the container using the provided `Dockerfile` and open the workspace inside.
 
 The container includes all Python and Node.js dependencies so you can run `pytest` and `npm test` directly inside the environment.
+
+## Local Setup
+
+If you prefer to work outside the development container:
+
+1. Create and activate a Python virtual environment:
+
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate  # On Windows use: venv\\Scripts\\activate
+   pip install -r requirements.txt
+   ```
+
+2. Install Node.js dependencies and set up Git hooks:
+
+   ```bash
+   npm install
+   ```
+
+   The `prepare` script runs `husky install` to configure commit hooks.
+
+Run `npm test` and `pytest` before opening a pull request to ensure everything passes.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ contextual automation, real-time reasoning, and cross-device awareness.
 - **Family/Team Dashboard** – Unified device and AI workflow management for everyone at home or work.
 
 ---
+
+## Development Setup
+
+```bash
+python3 -m venv venv
+source venv/bin/activate  # On Windows use: venv\Scripts\activate
+pip install -r requirements.txt
+npm install  # installs dependencies and sets up Husky git hooks
+```
+
+Run `pytest` and `npm test` to verify changes before submitting pull requests.

--- a/apps/actions-api/package.json
+++ b/apps/actions-api/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/src/index.js",
-    "test": "npm run build && node --test dist/test/*.test.js"
+    "test": "npm run build && node --test dist/test/*.test.js",
+    "prepare": "husky install"
   },
   "dependencies": {
     "express": "^5.1.0"
@@ -16,6 +17,7 @@
     "@types/express": "^5.0.3",
     "@types/node": "^24.2.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "husky": "^9.1.7"
   }
 }

--- a/docs/AI-Control-Center.md
+++ b/docs/AI-Control-Center.md
@@ -70,8 +70,9 @@ This code omits error handling and advanced features, but it shows a minimal app
 ## Troubleshooting
 
 - **Window does not appear** – Verify that ``tkinter`` is installed and that you
-  have access to a display. On Windows, ``python -m pip install tk`` installs the
-  required libraries.
+  have access to a display. On Windows, create a virtual environment with
+  ``python3 -m venv venv && source venv/bin/activate`` (``venv\\Scripts\\activate`` on
+  Windows) and run ``pip install tk`` to install the required libraries.
 - **Backend errors** – Ensure API keys are stored using the installer or
   environment variables. For local models, confirm the model path is correct and
   that dependencies such as ``transformers`` are installed.

--- a/docs/xr_support.md
+++ b/docs/xr_support.md
@@ -29,9 +29,11 @@ manager.register_voice_command("hello", on_hello)
 
 ## Setup
 
-Install Python bindings for your XR runtime of choice:
+Install Python bindings for your XR runtime of choice using a virtual environment:
 
 ```bash
+python3 -m venv venv
+source venv/bin/activate  # On Windows use: venv\Scripts\activate
 pip install openxr  # or webxr
 ```
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "react": "^19.1.1",
         "react-native": "^0.80.2"
+      },
+      "devDependencies": {
+        "husky": "^9.1.7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1833,6 +1836,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/image-size": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -4,10 +4,14 @@
   "private": true,
   "main": "App.js",
   "scripts": {
-    "start": "expo start"
+    "start": "expo start",
+    "prepare": "husky install"
   },
   "dependencies": {
     "react": "^19.1.1",
     "react-native": "^0.80.2"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.2.0",
+        "husky": "^9.1.7",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "echo \"(optional) build all workspaces\"",
     "test": "npm --workspaces --if-present test",
-    "prepare": "if [ -f node_modules/.bin/husky ]; then husky; fi"
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ litellm>=1.74.0,<1.76.0
 PyYAML>=6.0,<7.0
 markdown>=3.6,<4
 zeroconf>=0.147,<0.148
+Pillow
+psutil


### PR DESCRIPTION
## Summary
- add husky prepare scripts across packages
- document Python virtualenv and husky setup
- ignore local venv and include missing Python deps

## Testing
- `npm install`
- `npm test`
- `npm test` (mobile) *(fails: Missing script "test")*
- `python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && pytest` *(fails: ModuleNotFoundError: PIL, psutil)*


------
https://chatgpt.com/codex/tasks/task_e_689356c6d56c83268c3aa23893d488e1