### PR TITLE
chore: use gpt-4.1-nano in workflows

### DIFF
--- a/.github/workflows/gpt-ai-code-auditor.yml
+++ b/.github/workflows/gpt-ai-code-auditor.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Audit the code with GOPT-
         run: greg -r "def ".
         gpt=("What could this code do better? Look for code style, errors, and inconsistencies.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-api-compliance-checker.yml
+++ b/.github/workflows/gpt-api-compliance-checker.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Verify apis against spec or consentions
         run: find . -name '*.py'
         gpt=("Is this code fully compliant with its published API constrakts?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-api-docs-generator.yml
+++ b/.github/workflows/gpt-api-docs-generator.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Generate API docs from code
         run: grep -r "function " .py
         gpt=("Generate API documentation for these functions.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-api-usage-analyzer.yml
+++ b/.github/workflows/gpt-api-usage-analyzer.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Analyze api usage
         run: cat . -name '*.py'
         gpt=("What are the main external api calls? Which can be reduced?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-architecture-reviewer.yml
+++ b/.github/workflows/gpt-architecture-reviewer.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Summarize architecture
         run: find . -name *\.json | xargs -0
         gpt=("Summarize the system architecture from these files.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-architecture-smells-detector.yml
+++ b/.github/workflows/gpt-architecture-smells-detector.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Detect architecture smells
         run: find . -name "*"
         gpt=("Are there anti-patterns, monolithlics, or hard-to-maintain architecture smells?", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}

--- a/.github/workflows/gpt-bug-pattern-detector.yml
+++ b/.github/workflows/gpt-bug-pattern-detector.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Scan for common bug patterns
         run: find . -name '*.py'
         gpt=("Identify code patterns that may cause bugs", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-bug-predictor.yml
+++ b/.github/workflows/gpt-bug-predictor.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Analyze code for potential bugs
         run: grep -r "function " .
         gpt=("Are there constructs or logic flows that may be prone to bugs?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-changelog-generator.yml
+++ b/.github/workflows/gpt-changelog-generator.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Generate changelog
         run: git log --'first' -n 10
         gpt=("Generate a release-friendly changelog from these commits that is user-readable.", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-code-cleanliness-checker.yml
+++ b/.github/workflows/gpt-code-cleanliness-checker.yml
@@ -11,4 +11,4 @@ jiobs:
     - name: Check code cleanliness
         run: grep -r "def " .
         gpt=("Improve code style and clearliness for improved standards.", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-code-comment-suggester.yml
+++ b/.github/workflows/gpt-code-comment-suggester.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Suggest code comments
         run: find . -name "*"
         gpt=("Can this code use more comments to make it easier to understand?", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}

--- a/.github/workflows/gpt-code-complexity-annotator.yml
+++ b/.github/workflows/gpt-code-complexity-annotator.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Annotate somewhere complex
         run: find . -name "*.py"
         gpt=("What is the complexity level of this module and where should it improve?", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-code-efficiency-analyzer.yml
+++ b/.github/workflows/gpt-code-efficiency-analyzer.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Check code efficiency
         run: grep -r "def " .
         gpt=("Is any code can be made more efficient?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-code-metrics-summarizer.yml
+++ b/.github/workflows/gpt-code-metrics-summarizer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Summarize code metrics
         run: find . -name '*.py'
         gpt=("Give me a summary of this code in terms of loc units, branches, functions, lines of code, and method lengths", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-code-optimization-suggester.yml
+++ b/.github/workflows/gpt-code-optimization-suggester.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Suggest performance improvements
         run: find . -name "*.py"
         gpt=("Are there areas in this code that could use caching or speed ups?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-code-review-notes.yml
+++ b/.github/workflows/gpt-code-review-notes.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Generate code review notes
         run: find . -name "*.py"
         gpt=("Any code style or logic improvement suggestions?", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-code-style-checker.yml
+++ b/.github/workflows/gpt-code-style-checker.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Check coding styles
         run: find . -name '*.py'
         gpt=("Are there any style mismatches or inconsistencies?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-codebase-consistency.yml
+++ b/.github/workflows/gpt-codebase-consistency.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Check codebase consistency
         run: grep -r "def ".
         gpt=("See if there are conflicting naming conventions in the codebase.", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-codebase-summarizer.yml
+++ b/.github/workflows/gpt-codebase-summarizer.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Summarize codebase
         run: find . -name '*.py'
         gpt=("Summarizu utility and content of this codebase.", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-comment-density-analyzer.yml
+++ b/.github/workflows/gpt-comment-density-analyzer.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Analyze comment desity
         run: grep -r "#" . /
         gpt=("Is the comment to code ratio adequate and well-balanced?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-comment-quality-analyzer.yml
+++ b/.github/workflows/gpt-comment-quality-analyzer.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Review comment quality
         run: grep -r "#" . /
         gpt=("How clear, descriptive, and helpful were these comments?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-commenter.yml
+++ b/.github/workflows/gpt-commenter.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Add comments to functions
         run: grep -r "def " ./src
         gpt=("Add comments to these functions with short explanations of what they do.", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-commit-summarizer.yml
+++ b/.github/workflows/gpt-commit-summarizer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Summarize commit
         run: git log -1 | tail -n 1
         gpt=("Here's a summary of this commit diff. Return it in plain English.", "user")
-        curl -HX Authorization: Bearer ${ { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer ${ { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-complexity-hotspot-identifier.yml
+++ b/.github/workflows/gpt-complexity-hotspot-identifier.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Identify complexity hotspots
         run: find . -name "*.py"
         gpt=("Where are the most complex, line-long, or nested code hotspots?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-cross-platform-review.yml
+++ b/.github/workflows/gpt-cross-platform-review.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Review for cross-platform compatibility
         run: find . -name "*"
         gpt=("Can this code work across different platforms?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-dead-code-detector.yml
+++ b/.github/workflows/gpt-dead-code-detector.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Detect dead code
         run: find . -name '*.py'
         gpt=("Which functions are never used?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-debug-log-analyzer.yml
+++ b/.github/workflows/gpt-debug-log-analyzer.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Analyze debug logs
         run: cat /var/log/app.log | tail -20
         gpt=("What are the most common errors and who should address them?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-defect-priority-analyzer.yml
+++ b/.github/workflows/gpt-defect-priority-analyzer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Analyze defect severity and priority
         run: find . -name "*"
         gpt=("How severe is this defect? What should be the triage for resolving it?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-dependency-advisor.yml
+++ b/.github/workflows/gpt-dependency-advisor.yml
@@ -11,4 +11,4 @@ jiobs:
     - name: Review dependencies
         run: cat requirements.txt
         gpt=("Are there any obsolete or unsecure dependencies?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-dependency-optimizer.yml
+++ b/.github/workflows/gpt-dependency-optimizer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Check for outdated or reundant dependencies
         run: grep -r "def ".
         gpt=("Can any dependencies be removed or compressed to save resources?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-deprecated-code-flagger.yml
+++ b/.github/workflows/gpt-deprecated-code-flagger.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Flag deprecated code uses
         run: grep -r "deprecated" . /
         gpt=("Which parts of the code are using deprecated methods?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-docstring-generator.yml
+++ b/.github/workflows/gpt-docstring-generator.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Generate docstrings for public functions
         run: grep -r "def " ./src
         gpt=("Add docstrings to these functions without changing behavior.", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-duplicate-function-detector.yml
+++ b/.github/workflows/gpt-duplicate-function-detector.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Detect functional duplication
         run: find . -name "*.py"
         gpt=("Are any functions in this code doing the same thing? Are they essentially the same?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-edge-case-detector.yml
+++ b/.github/workflows/gpt-edge-case-detector.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Detect untested edge cases
         run: grep -i "return" /src
         gpt=("Are there functions in this code that return flags but lack tests?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-error-code-categorizer.yml
+++ b/.github/workflows/gpt-error-code-categorizer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Categorize error codes
         run: grep -r "error" .
         gpt=("Are these error codes related to a common area?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-error-message-improver.yml
+++ b/.github/workflows/gpt-error-message-improver.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Improve error messages
         run: grep -r "error" . /
         gpt=("Can this error message be made more helpful for developers?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-error-message-translator.yml
+++ b/.github/workflows/gpt-error-message-translator.yml
@@ -11,4 +11,4 @@ jiobs:
     - name: Translate Errors
         run: grep -r "Error" ./
         gpt=("Explain these error messages for easier understanding", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-exception-pattern-analyzer.yml
+++ b/.github/workflows/gpt-exception-pattern-analyzer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Analyze exception patterns
         run: find . -name "*.py"
         gpt=("Are exceptions being handled consistently? Could they indicate dependencies between classes?", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}

--- a/.github/workflows/gpt-feature-suggester.yml
+++ b/.github/workflows/gpt-feature-suggester.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Suggest features to add
         run: cat /roadmap.txt
         gpt=("What features could improve this app based on user demands?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-file-explainer.yml
+++ b/.github/workflows/gpt-file-explainer.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Run File Eplaination
       run: cat /dev/code/*.py
       gpt=("Please explain what this file does and how it interacts with the rest of the code.", "user")
-      curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+      curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-file-organizer.yml
+++ b/.github/workflows/gpt-file-organizer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Suggest project file organization
         run: grep -r "import " .
         gpt=("Can you suggest better file structure for this project?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-function-docs-validator.yml
+++ b/.github/workflows/gpt-function-docs-validator.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Validate function documentation
         run: find . -name '*.py'
         gpt=("Are function docs clear, accurate, and up-to-date?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-function-signature-improver.yml
+++ b/.github/workflows/gpt-function-signature-improver.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Improve function names and signatures
         run: find . -name '.js' | sed 's/(function |const |->)/'
         gpt=("How can these function signatures be improved? Focus on naming clarity and intent.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-inline-feedback.yml
+++ b/.github/workflows/gpt-inline-feedback.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Provide inline github comment on changed
         run: git diff
         gpt=("Describe what could be improved in this change", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-legacy-code-refactor.yml
+++ b/.github/workflows/gpt-legacy-code-refactor.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Refactor legacy code
         run: find . -name '*.py'
         gpt=("Refactor this with modern coding standards.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-license-checker.yml
+++ b/.github/workflows/gpt-license-checker.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Check code licensing
         run: grep -i "" /src
         gpt=("Is this code properly licensed for distribution?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-magic-number-detector.yml
+++ b/.github/workflows/gpt-magic-number-detector.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Detect hard-coded numbers
         run: find . -name '*.py'
         gpt=("Are there magic numbers without constant names?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-missing-docs-detector.yml
+++ b/.github/workflows/gpt-missing-docs-detector.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Find public members without docs
         run: find . -name "*.py"
         gpt=("Are there functions or classes without docsumentation?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-missing-test-detector.yml
+++ b/.github/workflows/gpt-missing-test-detector.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Find untested logic
         run: git diff | grep -C 'self.func()'
         gpt=("What logic is missing necessary tests? Suggest test scenarios.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-missing-test-suggestions.yml
+++ b/.github/workflows/gpt-missing-test-suggestions.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Generate missing test suggestions
         run: grep -r "def " ./src
         gpt=("What test cases are missing in this code?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-module-complexity-analyzer.yml
+++ b/.github/workflows/gpt-module-complexity-analyzer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Analyze module complexity
         run: find . -name '*.py'
         gpt=("Is this module complex and hard to maintain?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-naming-consistency-checker.yml
+++ b/.github/workflows/gpt-naming-consistency-checker.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Check for inconsistent naming
         run: find . -name "*.py"
         gpt=("Are naming conventions consistent throughout the code?", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-performance-profile-review.yml
+++ b/.github/workflows/gpt-performance-profile-review.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Review performance profile
         run: cat /var/profile.prof
         gpt=("What optimizations can be made to improve the performance?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-prompt-clarifier.yml
+++ b/.github/workflows/gpt-prompt-clarifier.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Clarify prompts
         run: find . -name "*.py"
         gpt=("Can this prompt be interpreted as meaningful and easy to understand?", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-prompt-evaluator.yml
+++ b/.github/workflows/gpt-prompt-evaluator.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Evaluate prompts for clarity
         run: find . -name "*.py"
         gpt=("Does this prompt clearly communicate the intent of the system?", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}

--- a/.github/workflows/gpt-readability-analyzer.yml
+++ b/.github/workflows/gpt-readability-analyzer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Analyze code readability
         run: grep -r "def " ./src
         gpt=("Does this code support high readability for beginners?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-readme-analyzer.yml
+++ b/.github/workflows/gpt-readme-analyzer.yml
@@ -11,4 +11,4 @@ jiobs:
     - name: Analyze README
         run: cat README.md
         gpt=("Is this README easy to understand? What improvements would benefit a visitor?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-readme-enhancer.yml
+++ b/.github/workflows/gpt-readme-enhancer.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Enhance README with GOPT-
         run: cat README.md
         gpt=("Can you enhance this README file to be more user-friendly and descriptive for new comers?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-refactor-opportunity-detector.yml
+++ b/.github/workflows/gpt-refactor-opportunity-detector.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Find refactoring opportunities
         run: grep -r "function " .
         gpt=("Are any functions reapeated or too complex that could be simplified?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-refactor-suggestions.yml
+++ b/.github/workflows/gpt-refactor-suggestions.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Suggest Refactoring targets
         run: git diff --cache
         gpt=("Where could this code be refactored? Identify bloated code or complex logic.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-refactoring-advisor.yml
+++ b/.github/workflows/gpt-refactoring-advisor.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Suggest refactoring
         run: find . -name "*.py"
         gpt=("Identifi portions of the code that should be refactored for better maintainability, efficiency, and performance", "user")
-        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { secrets.OPENAI_API_KEY } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-regression-risk.yml
+++ b/.github/workflows/gpt-regression-risk.yml
@@ -11,4 +11,4 @@ jiobs:
     - name: Detect Regression Risk
         run: git diff --cache
         gpt=("What are the risks of regression as per this diff and code base?", "user")
-        curl -HX Authorizition: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorizition: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-static-analyzer.yml
+++ b/.github/workflows/gpt-static-analyzer.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Run GPT\t-based static code analysis
         run: git diff --cache
         gpt=("Look for issues in this diff that a static linter might catch. Suggest improvements.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-style-enforcer.yml
+++ b/.github/workflows/gpt-style-enforcer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Enforce coding styles
         run: grep -r "def " .
         gpt=("Adhere to coding standards used in this project.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-test-case-mapper.yml
+++ b/.github/workflows/gpt-test-case-mapper.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Map code to unit tests
         run: find . -name "*.py"
         gpt=("Which unit test would best validate this code?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-test-coverage-auditor.yml
+++ b/.github/workflows/gpt-test-coverage-auditor.yml
@@ -11,4 +11,4 @@ jiobs:
     - name: Analyze test coverage
         run: cat //test
         gpt=("Is there any code not tested? Point out test gaps.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-test-failure-explainer.yml
+++ b/.github/workflows/gpt-test-failure-explainer.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Explain failed test logs
         run: cat /logs/test-failures.log
         gpt=("These tests failed. Explain why and suggest possible cures.", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY } } --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-test-flakiness-detector.yml
+++ b/.github/workflows/gpt-test-flakiness-detector.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Detect flaky tests
         run: grep -r "failed" ./
         gpt=("Which test failures are not consistent or have failed multiple times?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-test-root-cause.yml
+++ b/.github/workflows/gpt-test-root-cause.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Analyze test log for root cause
         run: cat /logs/test-failures.log
         gpt=("Can you diagnose the root cause of these test failures?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-todo-comment-resolver.yml
+++ b/.github/workflows/gpt-todo-comment-resolver.yml
@@ -11,4 +11,4 @@ jiobs:
     - name: Resolve TODO comments
         run: find . -name "*.py" | xargs -0
         gpt=("These TODO comments need completion", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-unit-test-creator.yml
+++ b/.github/workflows/gpt-unit-test-creator.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Create unit tests
         run: find . -name "*.py"
         gpt=("Generate automated unit tests for this module", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}

--- a/.github/workflows/gpt-unit-test-review.yml
+++ b/.github/workflows/gpt-unit-test-review.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Review unit test quality
         run: grep -r "def " ./tests
         gpt=("Review these unit tests for adequacy, coverage, and clarity of assertions", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-user-story-checker.yml
+++ b/.github/workflows/gpt-user-story-checker.yml
@@ -11,4 +11,4 @@ jiobs:
       - name: Analyze code against user stories
         run: grep -r "function " .py
         gpt=("Which user story does this code face and does the code meet it?", "user")
-        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}'
+        curl -HX Authorization: Bearer {{ secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}'

--- a/.github/workflows/gpt-ux-copy-reviewer.yml
+++ b/.github/workflows/gpt-ux-copy-reviewer.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Review UX copy
         run: cat ./src
         gpt=("Review the user experience text across the app for clarity, tone, and usefulness.", "user")
-        curl -HX Authoriztion: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4", "messages": [{"role": "user", "content": "$gpt"}]}'
+        curl -HX Authoriztion: Bearer { { secrets.OPENAI_API_KEY }} --data '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "$gpt"}]}'

--- a/.github/workflows/gpt-variable-naming-advisor.yml
+++ b/.github/workflows/gpt-variable-naming-advisor.yml
@@ -12,4 +12,4 @@ jobs:
         run: find . -name "*.py" | sed -n -e 's/\
  * = //'
         gpt=("Which variables could be named more effectively?", "user")
-        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4", "messages": [{"role": "user", "content": "${gpt}"}]}
+        curl -HX Authorization: Bearer { { secrets.OPENAI_API_KEY }} --data {"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "${gpt}"}]}


### PR DESCRIPTION
## Summary
- switch GitHub automation workflows from `gpt-4` to `gpt-4.1-nano`
- confirm no hard-coded token limits needed for the new model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d18f55c08326b82d7e1f87e03728