### PR TITLE
refactor: add reusable gpt request action

### DIFF
--- a/.github/actions/gpt-request/action.yml
+++ b/.github/actions/gpt-request/action.yml
@@ -1,0 +1,23 @@
+name: GPT Request
+description: Send prompt and file contents to OpenAI API
+inputs:
+  prompt:
+    description: Prompt to prefix to file contents
+    required: true
+  model:
+    description: Model to use
+    required: false
+    default: gpt-4.1-nano
+  file_path:
+    description: Path to file whose contents will be appended to the prompt
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: node $GITHUB_ACTION_PATH/index.js
+      shell: bash
+      env:
+        OPENAI_API_KEY: ${{ env.OPENAI_API_KEY }}
+        PROMPT: ${{ inputs.prompt }}
+        MODEL: ${{ inputs.model }}
+        FILE_PATH: ${{ inputs.file_path }}

--- a/.github/actions/gpt-request/index.js
+++ b/.github/actions/gpt-request/index.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+
+const apiKey = process.env.OPENAI_API_KEY;
+const prompt = process.env.PROMPT;
+const model = process.env.MODEL || 'gpt-4.1-nano';
+const filePath = process.env.FILE_PATH;
+
+if (!apiKey) {
+  console.error('OPENAI_API_KEY is not set');
+  process.exit(1);
+}
+
+const fileContent = fs.readFileSync(filePath, 'utf8');
+
+const payload = {
+  model,
+  messages: [{ role: 'user', content: `${prompt}\n${fileContent}` }],
+};
+
+(async () => {
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const text = await response.text();
+  console.log(text);
+})();

--- a/.github/workflows/gpt-review.yml
+++ b/.github/workflows/gpt-review.yml
@@ -19,28 +19,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Prepare commit message
+        run: git log -1 --pretty=%B > commit_message.txt
       - name: Review commit message
+        uses: ./.github/actions/gpt-request
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          git log -1 --pretty=%B > commit_message.txt
-          curl -s -X POST \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "{\"model\":\"gpt-4.1-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Are these commit messages clear, descriptive, and actionable?\\n$(cat commit_message.txt)\"}]}" \
-            https://api.openai.com/v1/chat/completions
+        with:
+          prompt: |
+            Are these commit messages clear, descriptive, and actionable?
+          file_path: commit_message.txt
+          model: gpt-4.1-mini
 
   commit-summary:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Generate diff
+        run: git diff HEAD^ HEAD > changes.diff
       - name: Summarize changes
+        uses: ./.github/actions/gpt-request
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          git diff HEAD^ HEAD > changes.diff
-          curl -s -X POST \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "{\"model\":\"gpt-4.1-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"Provide a concise summary of these changes:\\n$(cat changes.diff)\"}]}" \
-            https://api.openai.com/v1/chat/completions
+        with:
+          prompt: |
+            Provide a concise summary of these changes:
+          file_path: changes.diff
+          model: gpt-4.1-mini


### PR DESCRIPTION
## Summary
- add `gpt-request` composite action for sending prompts and file contents to OpenAI
- call the new action from `gpt-review.yml` for commit message and change summaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893d6bd3bec8326b3704ebe56880f9a