### PR TITLE
ci: add OpenAI key check workflow and document required secret

### DIFF
--- a/.github/workflows/openai-key-check.yml
+++ b/.github/workflows/openai-key-check.yml
@@ -1,0 +1,17 @@
+name: OpenAI Key Check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test OpenAI API key
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          curl --fail -sS -X POST https://api.openai.com/v1/responses \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+            -d '{"model":"gpt-4o-mini","input":"ping"}' > /dev/null

--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ The repository uses a single workflow, [`gpt-review.yml`](.github/workflows/gpt-
 - **commit-summary** – produces a short summary of the most recent changes.
 
 Set the `OPENAI_API_KEY` secret to enable these jobs.
+
+## GitHub Actions Secrets
+
+The GPT-powered workflows require an OpenAI API key.
+
+1. In your repository on GitHub, navigate to **Settings > Secrets and variables > Actions**.
+2. Choose **New repository secret** and name it `OPENAI_API_KEY`.
+3. Paste your OpenAI API key and save.
+
+A lightweight workflow, [`openai-key-check.yml`](.github/workflows/openai-key-check.yml), is available to verify the secret. Run it from the **Actions** tab to confirm the key is configured correctly.


### PR DESCRIPTION
## Summary
- document how to set `OPENAI_API_KEY` for GitHub Actions
- add `openai-key-check.yml` to validate the OpenAI API key

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893de4c212c8326801b82acd0367912