### PR TITLE
ci: use gpt-4.1-nano in GPT workflows

### DIFF
--- a/.github/workflows/gpt-review.yml
+++ b/.github/workflows/gpt-review.yml
@@ -12,8 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: ChatGPT Code Review
         uses: anc95/ChatGPT-CodeReview@v1.0.22
-        with:
-          openai_key: ${{ secrets.OPENAI_API_KEY }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          MODEL: gpt-4.1-nano
 
   commit-message-review:
     runs-on: ubuntu-latest
@@ -29,7 +31,7 @@ jobs:
           prompt: |
             Are these commit messages clear, descriptive, and actionable?
           file_path: commit_message.txt
-          model: gpt-4.1-mini
+          model: gpt-4.1-nano
 
   commit-summary:
     runs-on: ubuntu-latest
@@ -45,4 +47,4 @@ jobs:
           prompt: |
             Provide a concise summary of these changes:
           file_path: changes.diff
-          model: gpt-4.1-mini
+          model: gpt-4.1-nano

--- a/.github/workflows/openai-key-check.yml
+++ b/.github/workflows/openai-key-check.yml
@@ -14,4 +14,4 @@ jobs:
           curl --fail -sS -X POST https://api.openai.com/v1/responses \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${OPENAI_API_KEY}" \
-            -d '{"model":"gpt-4o-mini","input":"ping"}' > /dev/null
+            -d '{"model":"gpt-4.1-nano","input":"ping"}' > /dev/null

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Run `pytest` and `npm test` to verify changes before submitting pull requests.
 
 ## GPT-based Workflows
 
-The repository uses a single workflow, [`gpt-review.yml`](.github/workflows/gpt-review.yml), to run GPT-powered checks:
+All AI-assisted jobs use the `gpt-4.1-nano` model. A single workflow, [`gpt-review.yml`](.github/workflows/gpt-review.yml), runs GPT-powered checks through a reusable [composite action](.github/actions/gpt-request/action.yml):
 
 - **code-review** – runs the ChatGPT Code Review action on pull requests.
 - **commit-message-review** – ensures the latest commit message is clear and actionable.
@@ -57,4 +57,4 @@ The GPT-powered workflows require an OpenAI API key.
 2. Choose **New repository secret** and name it `OPENAI_API_KEY`.
 3. Paste your OpenAI API key and save.
 
-A lightweight workflow, [`openai-key-check.yml`](.github/workflows/openai-key-check.yml), is available to verify the secret. Run it from the **Actions** tab to confirm the key is configured correctly.
+A lightweight workflow, [`openai-key-check.yml`](.github/workflows/openai-key-check.yml), verifies the secret by calling `gpt-4.1-nano`. Run it from the **Actions** tab to confirm the key is configured correctly.


### PR DESCRIPTION
## Summary
- switch GPT review jobs to gpt-4.1-nano and clean up config
- verify OPENAI_API_KEY by pinging gpt-4.1-nano
- document default model in README

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ceb83c7c8326ae7aaa77f33352d0