### PR TITLE
Add stale issue workflow and document policy

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,1 +1,22 @@
-name: Close Stale Issues and PRson:  schedule:    - cron: '0 0 * * *'  workflow_dispatch:jobs:  stale:    runs-on: ubuntu-latest    steps:      - uses: actions/stale@v9        with:          repo-token: ${{ secrets.GITHUB_TOKEN }}          days-before-stale: 30          days-before-close: 60          stale-issue-label: stale          stale-pr-label: stale          stale-issue-message: 'This issue has been automatically marked as stale due to inactivity.'          stale-pr-message: 'This pull request has been automatically marked as stale due to inactivity.'          close-issue-message: 'Closing this issue after prolonged inactivity.'          close-pr-message: 'Closing this pull request after prolonged inactivity.'
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 60
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: 'This issue has been automatically marked as stale due to inactivity.'
+          stale-pr-message: 'This pull request has been automatically marked as stale due to inactivity.'
+          close-issue-message: 'Closing this issue after prolonged inactivity.'
+          close-pr-message: 'Closing this pull request after prolonged inactivity.'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ Please ensure tests pass locally before requesting a review.
 - Before pushing, run `git fetch origin && git rebase origin/main`.
 - Resolve conflicts locally before opening or refreshing a PR.
 
+## Inactive Issues and Pull Requests
+
+Issues and pull requests with no activity for 30 days are automatically labeled `stale` and may be closed after 60 days. Add a comment or push a new commit to keep the discussion active.
+
 ## Releases
 
 - Draft releases are updated automatically whenever changes are merged to `main`.


### PR DESCRIPTION
## Summary
- add scheduled stale workflow to label and close inactive issues and PRs
- document stale issue/PR policy in contributing guide

## Testing
- `npm test` *(fails: Cannot find module '/workspace/Windows-AI/tests/run.mjs')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51253c5fc832691d90be0f70ab2cd