### PR TITLE
Handle downstream service errors in AgentHub pipeline

### DIFF
--- a/apps/agenthub/main.py
+++ b/apps/agenthub/main.py
@@ -46,8 +46,15 @@ class AgentHub:
 
 hub = AgentHub()
 
-ACTIONS_URL = os.getenv("ACTIONS_URL", "http://localhost:3000/api/actions/execute")
-PROXY_URL = os.getenv("PROXY_URL", "http://localhost:11434/v1/chat/completions")
+# Base URLs for downstream services. These can be overridden via
+# environment variables to support custom deployments, while still
+# providing sensible local defaults.
+ACTIONS_URL = os.environ.get(
+    "ACTIONS_URL", "http://localhost:3000/api/actions/execute"
+)
+PROXY_URL = os.environ.get(
+    "PROXY_URL", "http://localhost:11434/v1/chat/completions"
+)
 
 @app.get("/health")
 async def health():
@@ -62,8 +69,12 @@ async def pipeline_sample():
             )
             action.raise_for_status()
             action_data = action.json()
-        except httpx.HTTPError as exc:
+        except httpx.RequestError as exc:
             return {"error": f"Action service unreachable: {exc}"}
+        except httpx.HTTPStatusError as exc:
+            return {
+                "error": f"Action service error: {exc.response.status_code}"
+            }
 
         try:
             proxy = await client.post(
@@ -71,8 +82,16 @@ async def pipeline_sample():
             )
             proxy.raise_for_status()
             proxy_data = proxy.json()
-        except httpx.HTTPError as exc:
-            return {"action": action_data, "error": f"Proxy service unreachable: {exc}"}
+        except httpx.RequestError as exc:
+            return {
+                "action": action_data,
+                "error": f"Proxy service unreachable: {exc}",
+            }
+        except httpx.HTTPStatusError as exc:
+            return {
+                "action": action_data,
+                "error": f"Proxy service error: {exc.response.status_code}",
+            }
 
     return {"action": action_data, "proxy": proxy_data}
 

--- a/tests/test_agenthub.py
+++ b/tests/test_agenthub.py
@@ -66,3 +66,36 @@ def test_proxy_service_unreachable(monkeypatch):
     data = resp.json()
     assert data["action"] == {"ok": True}
     assert data["error"].startswith("Proxy service unreachable")
+
+
+def test_action_service_http_error(monkeypatch):
+    main = get_app(monkeypatch)
+
+    async def mock_post(self, url, *args, **kwargs):
+        if url == main.ACTIONS_URL:
+            return httpx.Response(500, request=httpx.Request("POST", url))
+        return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    client = TestClient(main.app)
+    resp = client.post("/pipeline/sample")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"].startswith("Action service error")
+
+
+def test_proxy_service_http_error(monkeypatch):
+    main = get_app(monkeypatch)
+
+    async def mock_post(self, url, *args, **kwargs):
+        if url == main.ACTIONS_URL:
+            return httpx.Response(200, json={"ok": True}, request=httpx.Request("POST", url))
+        return httpx.Response(502, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", mock_post)
+    client = TestClient(main.app)
+    resp = client.post("/pipeline/sample")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["action"] == {"ok": True}
+    assert data["error"].startswith("Proxy service error")


### PR DESCRIPTION
## Summary
- Read proxy and action service URLs from environment variables with defaults
- Gracefully handle downstream connection failures and HTTP errors in the pipeline sample endpoint
- Add tests for custom URLs and various failure scenarios

## Testing
- `pytest tests/test_agenthub.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5129187748326acd421ec5c068976