### PR TITLE
feat(actions-api): run ts tests via ts-node

### DIFF
--- a/.github/workflows/actions-api-tests.yml
+++ b/.github/workflows/actions-api-tests.yml
@@ -1,0 +1,21 @@
+name: Actions API Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        working-directory: apps/actions-api
+        run: npm install
+      - name: Run tests
+        working-directory: apps/actions-api
+        run: npm test

--- a/apps/actions-api/package.json
+++ b/apps/actions-api/package.json
@@ -1,1 +1,23 @@
-{  "name": "actions-api",  "version": "1.0.0",  "description": "Express Actions API for Windows AI",  "main": "dist/src/index.js",  "type": "commonjs",  "scripts": {    "build": "tsc",    "start": "node dist/src/index.js",    "test": "npm run build && node --test dist/test/*.test.js",    "prepare": "husky install"  },  "dependencies": {    "express": "^5.1.0"  },  "devDependencies": {    "@types/express": "^5.0.3",    "@types/node": "^24.2.0",    "ts-node": "^10.9.2",    "typescript": "^5.9.2",    "husky": "^9.1.7"  }}
+{
+  "name": "actions-api",
+  "version": "1.0.0",
+  "description": "Express Actions API for Windows AI",
+  "main": "dist/src/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/src/index.js",
+    "test": "node --loader ts-node/esm --test test/*.test.ts",
+    "prepare": "husky install"
+  },
+  "dependencies": {
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.3",
+    "@types/node": "^24.2.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2",
+    "husky": "^9.1.7"
+  }
+}

--- a/apps/actions-api/src/index.ts
+++ b/apps/actions-api/src/index.ts
@@ -1,1 +1,144 @@
-import express from 'express';import { executeAction } from './actions';import { normalize } from './normalize';import { ValidationError } from './errors';import { createPairingToken, handleRemoteCommand } from './mobile';import { distributeTask } from './mesh';import { handleDeviceEvent } from './iot';import { searchDocuments } from './search';export const app = express();app.use(express.json());app.post('/api/mobile/pair', (req, res) => {  try {    const token = createPairingToken(req.body.deviceId);    res.json({ ok: true, token });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/mobile/command', async (req, res) => {  try {    const { token, ...body } = req.body;    const result = await handleRemoteCommand(token, body);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/actions/execute', async (req, res) => {  try {    const norm = normalize(req.body);    const result = await executeAction(norm);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/mesh/distribute', (req, res) => {  try {    const result = distributeTask(req.body);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/iot/event', (req, res) => {  try {    const result = handleDeviceEvent(req.body);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/search/query', (req, res) => {  try {    const result = searchDocuments(req.body);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});if (require.main === module) {  const port = process.env.PORT || 3000;  app.listen(port, () => {    console.log(      JSON.stringify({ level: 'info', message: 'actions api listening', port })    );  });}
+import express from 'express';
+import { executeAction } from './actions';
+import { normalize } from './normalize';
+import { ValidationError } from './errors';
+import { createPairingToken, handleRemoteCommand } from './mobile';
+import { distributeTask } from './mesh';
+import { handleDeviceEvent } from './iot';
+import { searchDocuments } from './search';
+import { fileURLToPath } from 'node:url';
+
+export const app = express();
+
+app.use(express.json());
+
+app.post('/api/mobile/pair', (req, res) => {
+  try {
+    const token = createPairingToken(req.body.deviceId);
+    res.json({ ok: true, token });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack,
+        }),
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/mobile/command', async (req, res) => {
+  try {
+    const { token, ...body } = req.body;
+    const result = await handleRemoteCommand(token, body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack,
+        }),
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/actions/execute', async (req, res) => {
+  try {
+    const norm = normalize(req.body);
+    const result = await executeAction(norm);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack,
+        }),
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/mesh/distribute', (req, res) => {
+  try {
+    const result = distributeTask(req.body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack,
+        }),
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/iot/event', (req, res) => {
+  try {
+    const result = handleDeviceEvent(req.body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack,
+        }),
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/search/query', (req, res) => {
+  try {
+    const result = searchDocuments(req.body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({
+          level: 'error',
+          message: err.message,
+          stack: err.stack,
+        }),
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(
+      JSON.stringify({ level: 'info', message: 'actions api listening', port }),
+    );
+  });
+}

--- a/apps/actions-api/tsconfig.json
+++ b/apps/actions-api/tsconfig.json
@@ -1,1 +1,14 @@
-{  "compilerOptions": {    "target": "ES2020",    "module": "commonjs",    "outDir": "dist",    "esModuleInterop": true,    "forceConsistentCasingInFileNames": true,    "strict": true,    "skipLibCheck": true  },  "include": ["src/**/*", "test/**/*"],  "exclude": ["dist"]}
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- run actions-api test suite with Node's test runner and ts-node ESM loader
- adopt NodeNext TypeScript config for actions-api
- add CI workflow to install deps and run the actions-api tests

## Testing
- `npm test` (failed: Cannot find module '/workspace/Windows-AI/apps/actions-api/src/actions')

------
https://chatgpt.com/codex/tasks/task_e_68b5129fe1a4832688ae8cfbf01fa5b9