### PR TITLE
feat: add mobile pairing endpoints and app scaffolds

### DIFF
--- a/apps/actions-api/src/index.ts
+++ b/apps/actions-api/src/index.ts
@@ -1,1 +1,116 @@
-import express from 'express';import { executeAction } from './actions';import { normalize } from './normalize';import { ValidationError } from './errors';import { createPairingToken, handleRemoteCommand } from './mobile';import { distributeTask } from './mesh';import { handleDeviceEvent } from './iot';import { searchDocuments } from './search';export const app = express();app.use(express.json());app.post('/api/mobile/pair', (req, res) => {  try {    const token = createPairingToken(req.body.deviceId);    res.json({ ok: true, token });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/mobile/command', async (req, res) => {  try {    const { token, ...body } = req.body;    const result = await handleRemoteCommand(token, body);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/actions/execute', async (req, res) => {  try {    const norm = normalize(req.body);    const result = await executeAction(norm);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/mesh/distribute', (req, res) => {  try {    const result = distributeTask(req.body);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/iot/event', (req, res) => {  try {    const result = handleDeviceEvent(req.body);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});app.post('/api/search/query', (req, res) => {  try {    const result = searchDocuments(req.body);    res.json({ ok: true, result });  } catch (err: any) {    if (err instanceof ValidationError) {      res.status(400).json({ ok: false, error: { message: err.message } });    } else {      console.error(        JSON.stringify({          level: 'error',          message: err.message,          stack: err.stack        })      );      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });    }  }});if (require.main === module) {  const port = process.env.PORT || 3000;  app.listen(port, () => {    console.log(      JSON.stringify({ level: 'info', message: 'actions api listening', port })    );  });}
+import express from 'express';
+import { executeAction } from './actions';
+import { normalize } from './normalize';
+import { ValidationError } from './errors';
+import { createPairingToken, handleRemoteCommand } from './mobile';
+import { distributeTask } from './mesh';
+import { handleDeviceEvent } from './iot';
+import { searchDocuments } from './search';
+
+export const app = express();
+app.use(express.json());
+
+app.post('/api/mobile/pair', (req, res) => {
+  try {
+    const token = createPairingToken(req.body.deviceId);
+    res.json({ ok: true, token });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({ level: 'error', message: err.message, stack: err.stack })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/mobile/command', async (req, res) => {
+  try {
+    const { token, ...body } = req.body;
+    const result = await handleRemoteCommand(token, body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({ level: 'error', message: err.message, stack: err.stack })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/actions/execute', async (req, res) => {
+  try {
+    const norm = normalize(req.body);
+    const result = await executeAction(norm);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({ level: 'error', message: err.message, stack: err.stack })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/mesh/distribute', (req, res) => {
+  try {
+    const result = distributeTask(req.body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({ level: 'error', message: err.message, stack: err.stack })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/iot/event', (req, res) => {
+  try {
+    const result = handleDeviceEvent(req.body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({ level: 'error', message: err.message, stack: err.stack })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+app.post('/api/search/query', (req, res) => {
+  try {
+    const result = searchDocuments(req.body);
+    res.json({ ok: true, result });
+  } catch (err: any) {
+    if (err instanceof ValidationError) {
+      res.status(400).json({ ok: false, error: { message: err.message } });
+    } else {
+      console.error(
+        JSON.stringify({ level: 'error', message: err.message, stack: err.stack })
+      );
+      res.status(500).json({ ok: false, error: { message: 'Internal server error' } });
+    }
+  }
+});
+
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(JSON.stringify({ level: 'info', message: 'actions api listening', port }));
+  });
+}

--- a/apps/actions-api/src/iot.ts
+++ b/apps/actions-api/src/iot.ts
@@ -1,1 +1,16 @@
-import { ValidationError } from './errors';export interface DeviceEventRequest {  deviceId: string;  event: string;}export function handleDeviceEvent(req: DeviceEventRequest) {  const deviceId = req.deviceId?.trim();  const event = req.event?.trim();  if (!deviceId || !event) {    throw new ValidationError('Missing deviceId or event');  }  // Placeholder implementation  return { deviceId, event };}
+import { ValidationError } from './errors';
+
+export interface DeviceEventRequest {
+  deviceId: string;
+  event: string;
+}
+
+export function handleDeviceEvent(req: DeviceEventRequest) {
+  const deviceId = req.deviceId?.trim();
+  const event = req.event?.trim();
+  if (!deviceId || !event) {
+    throw new ValidationError('Missing deviceId or event');
+  }
+  // Placeholder implementation
+  return { deviceId, event };
+}

--- a/apps/actions-api/src/mesh.ts
+++ b/apps/actions-api/src/mesh.ts
@@ -1,1 +1,12 @@
-import { ValidationError } from './errors';export interface MeshTaskRequest {  task: string;}export function distributeTask(req: MeshTaskRequest) {  const task = req.task?.trim();  if (!task) throw new ValidationError('Missing task');  // Placeholder implementation until mesh integration is complete  return { distributed: task };}
+import { ValidationError } from './errors';
+
+export interface MeshTaskRequest {
+  task: string;
+}
+
+export function distributeTask(req: MeshTaskRequest) {
+  const task = req.task?.trim();
+  if (!task) throw new ValidationError('Missing task');
+  // Placeholder implementation until mesh integration is complete
+  return { distributed: task };
+}

--- a/apps/actions-api/src/mobile.ts
+++ b/apps/actions-api/src/mobile.ts
@@ -1,1 +1,30 @@
-import crypto from 'node:crypto';import { executeAction } from './actions';import { normalize } from './normalize';import { ValidationError } from './errors';const tokens = new Set<string>();export function createPairingToken(deviceId: string): string {  if (!deviceId) {    throw new ValidationError('deviceId is required');  }  const token = crypto.randomBytes(16).toString('hex');  tokens.add(token);  return token;}export async function handleRemoteCommand(  token: string,  body: unknown): Promise<unknown> {  if (!tokens.has(token)) {    throw new ValidationError('Invalid token');  }  const norm = normalize(body as any);  return await executeAction(norm);}
+import crypto from 'node:crypto';
+import { executeAction } from './actions';
+import { normalize } from './normalize';
+import { ValidationError } from './errors';
+
+interface TokenInfo {
+  deviceId: string;
+  expiresAt: number;
+}
+
+const TOKEN_TTL_MS = 60 * 60 * 1000;
+const tokens = new Map<string, TokenInfo>();
+
+export function createPairingToken(deviceId: string): string {
+  if (!deviceId) {
+    throw new ValidationError('deviceId is required');
+  }
+  const token = crypto.randomBytes(16).toString('hex');
+  tokens.set(token, { deviceId, expiresAt: Date.now() + TOKEN_TTL_MS });
+  return token;
+}
+
+export async function handleRemoteCommand(token: string, body: unknown): Promise<unknown> {
+  const info = tokens.get(token);
+  if (!info || info.expiresAt < Date.now()) {
+    throw new ValidationError('Invalid token');
+  }
+  const norm = normalize(body as any);
+  return await executeAction(norm);
+}

--- a/apps/mobile/android/MainActivity.kt
+++ b/apps/mobile/android/MainActivity.kt
@@ -1,0 +1,68 @@
+package com.windowsai
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import android.os.Bundle
+import android.app.Activity
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import java.net.HttpURLConnection
+import java.net.URL
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        createChannel()
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel("default", "Default", NotificationManager.IMPORTANCE_DEFAULT)
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    fun showNotification(message: String) {
+        val builder = NotificationCompat.Builder(this, "default")
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle("Windows AI")
+            .setContentText(message)
+        NotificationManagerCompat.from(this).notify(1, builder.build())
+    }
+
+    fun pair(deviceId: String, callback: (String?) -> Unit) {
+        Thread {
+            try {
+                val url = URL("http://localhost:3000/api/mobile/pair")
+                val conn = url.openConnection() as HttpURLConnection
+                conn.requestMethod = "POST"
+                conn.setRequestProperty("Content-Type", "application/json")
+                conn.doOutput = true
+                val body = "{\"deviceId\":\"$deviceId\"}"
+                conn.outputStream.use { it.write(body.toByteArray()) }
+                val response = conn.inputStream.bufferedReader().use { it.readText() }
+                val token = Regex("\"token\":\"(.*?)\"").find(response)?.groupValues?.get(1)
+                callback(token)
+            } catch (e: Exception) {
+                callback(null)
+            }
+        }.start()
+    }
+
+    fun sendCommand(token: String, action: String) {
+        Thread {
+            try {
+                val url = URL("http://localhost:3000/api/mobile/command")
+                val conn = url.openConnection() as HttpURLConnection
+                conn.requestMethod = "POST"
+                conn.setRequestProperty("Content-Type", "application/json")
+                conn.doOutput = true
+                val body = "{\"token\":\"$token\",\"action\":\"$action\"}"
+                conn.outputStream.use { it.write(body.toByteArray()) }
+                conn.inputStream.close()
+            } catch (_: Exception) {}
+        }.start()
+    }
+}

--- a/apps/mobile/ios/AppDelegate.swift
+++ b/apps/mobile/ios/AppDelegate.swift
@@ -1,0 +1,43 @@
+import UIKit
+import UserNotifications
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        return true
+    }
+
+    func showNotification(_ message: String) {
+        let content = UNMutableNotificationContent()
+        content.title = "Windows AI"
+        content.body = message
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
+    }
+
+    func pair(deviceId: String, completion: @escaping (String?) -> Void) {
+        var request = URLRequest(url: URL(string: "http://localhost:3000/api/mobile/pair")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = "{\"deviceId\":\"\(deviceId)\"}".data(using: .utf8)
+        URLSession.shared.dataTask(with: request) { data, _, _ in
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let token = json["token"] as? String else {
+                completion(nil)
+                return
+            }
+            completion(token)
+        }.resume()
+    }
+
+    func sendCommand(token: String, action: String) {
+        var request = URLRequest(url: URL(string: "http://localhost:3000/api/mobile/command")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = "{\"token\":\"\(token)\",\"action\":\"\(action)\"}".data(using: .utf8)
+        URLSession.shared.dataTask(with: request).resume()
+    }
+}

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -1,0 +1,25 @@
+# Mobile Pairing
+
+The Windows AI mobile apps can pair with the Actions API to enable remote control.
+
+## Pairing a Device
+1. Send a POST request to `/api/mobile/pair` with a JSON body containing a unique `deviceId`.
+2. The server returns a pairing `token` that is valid for one hour.
+3. Store the token securely on the device.
+
+```bash
+curl -X POST http://localhost:3000/api/mobile/pair \
+  -H "content-type: application/json" \
+  -d '{"deviceId":"device-123"}'
+```
+
+## Sending Remote Commands
+Use the pairing token to issue commands.
+
+```bash
+curl -X POST http://localhost:3000/api/mobile/command \
+  -H "content-type: application/json" \
+  -d '{"token":"<token>","action":"get_system_info"}'
+```
+
+The server executes the requested action and returns the result.


### PR DESCRIPTION
## Summary
- add pairing token store with remote command endpoint in actions API
- scaffold Android and iOS mobile apps with notification and control helpers
- document mobile pairing workflow

## Testing
- `npm --prefix apps/actions-api test`

------
https://chatgpt.com/codex/tasks/task_e_68b512b543988326a655450349de48be