### PR TITLE
Add encrypted cloud sync helpers and hybrid backend selection

### DIFF
--- a/cloud_sync/__init__.py
+++ b/cloud_sync/__init__.py
@@ -143,6 +143,27 @@ class CloudSync:
             return "downloaded"
         raise RuntimeError("sync conflict")
 
+    # --- Convenience helpers ---------------------------------------------
+    def backup_profile(self, profile_path: str | Path) -> None:
+        """Encrypt and upload the user profile."""
+
+        self.backup_file(profile_path, "profile")
+
+    def restore_profile(self, profile_path: str | Path) -> bool:
+        """Restore the user profile if available."""
+
+        return self.restore_file(profile_path, "profile")
+
+    def backup_model(self, model_path: str | Path, model_name: str) -> None:
+        """Encrypt and upload a model file under ``model_name``."""
+
+        self.backup_file(model_path, f"models/{model_name}")
+
+    def restore_model(self, model_path: str | Path, model_name: str) -> bool:
+        """Restore a model file previously backed up."""
+
+        return self.restore_file(model_path, f"models/{model_name}")
+
 
 __all__ = [
     "Provider",

--- a/docs/cloud_sync.md
+++ b/docs/cloud_sync.md
@@ -6,6 +6,10 @@ password before leaving the local machine.  The default implementation ships
 with an in-memory provider used for testing, while real deployments can supply
 implementations for services like S3, Dropbox or Google Drive.
 
+Convenience helpers like `backup_profile`, `restore_profile`, `backup_model` and
+`restore_model` wrap the lower level file APIs and apply a simple naming
+convention for the stored blobs.
+
 ## Basic Usage
 
 ```python
@@ -14,7 +18,15 @@ from cloud_sync import CloudSync, InMemoryProvider
 provider = InMemoryProvider()
 sync = CloudSync(provider, password="secret", conflict_resolution="local")
 
-sync.backup_file("profile.json", "profile")
+# back up a profile
+sync.backup_profile("profile.json")
+
+# back up a downloaded model
+sync.backup_model("models/llama.bin", "llama.bin")
+
+# later restore
+sync.restore_profile("profile.json")
+sync.restore_model("models/llama.bin", "llama.bin")
 ```
 
 ## Conflict Resolution

--- a/installer/gui_installer.py
+++ b/installer/gui_installer.py
@@ -106,13 +106,15 @@ class GUIInstaller:
             self.info.delete("1.0", tk.END)
             for k, v in info.items():
                 self.info.insert(tk.END, f"{k}: {v}\n")
-            if self.auto_select:
+            if self.auto_select or self.backend == "hybrid":
                 backend = model_selector.select_backend("default", self.model_specs)
                 self.backend = backend
-                self.info.insert(
-                    tk.END,
-                    _("Recommended backend: {backend}").format(backend=backend) + "\n",
+                msg = (
+                    _("Recommended backend: {backend}")
+                    if self.auto_select
+                    else _("Hybrid backend resolved to {backend}")
                 )
+                self.info.insert(tk.END, msg.format(backend=backend) + "\n")
             else:
                 self.info.insert(
                     tk.END,
@@ -205,14 +207,17 @@ class GUIInstaller:
             top, text=_("Automatic model selection"), variable=auto_var
         ).pack(anchor="w", padx=10, pady=5)
 
-        manual_var = tk.StringVar(value=self.backend or "remote")
+        manual_var = tk.StringVar(value=self.backend or "hybrid")
         manual_frame = ttk.LabelFrame(top, text=_("Manual backend"))
         manual_frame.pack(fill="x", padx=10, pady=5)
         ttk.Radiobutton(
             manual_frame, text=_("Local"), variable=manual_var, value="local"
         ).pack(side=tk.LEFT, padx=5)
         ttk.Radiobutton(
-            manual_frame, text=_("Remote"), variable=manual_var, value="remote"
+            manual_frame, text=_("Cloud"), variable=manual_var, value="remote"
+        ).pack(side=tk.LEFT, padx=5)
+        ttk.Radiobutton(
+            manual_frame, text=_("Hybrid"), variable=manual_var, value="hybrid"
         ).pack(side=tk.LEFT, padx=5)
 
         specs_frame = ttk.LabelFrame(top, text=_("Advanced requirements"))

--- a/tests/test_cloud_sync.py
+++ b/tests/test_cloud_sync.py
@@ -57,3 +57,21 @@ def test_filesystem_provider_round_trip(tmp_path):
     local.unlink()
     assert sync.restore_file(local, "data")
     assert local.read_text() == "hello"
+
+
+def test_profile_and_model_helpers(tmp_path):
+    provider = InMemoryProvider()
+    sync = CloudSync(provider, "pw")
+    profile = tmp_path / "profile.json"
+    profile.write_text("p")
+    sync.backup_profile(profile)
+    profile.unlink()
+    assert sync.restore_profile(profile)
+    assert profile.read_text() == "p"
+
+    model = tmp_path / "model.bin"
+    model.write_text("m")
+    sync.backup_model(model, "m.bin")
+    model.unlink()
+    assert sync.restore_model(model, "m.bin")
+    assert model.read_text() == "m"


### PR DESCRIPTION
## Summary
- extend cloud_sync with profile/model backup helpers
- document encrypted cloud backup usage
- support hybrid local/cloud backend choice in GUI installer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b512b787a883269d10450d4ebe97f2