### PR TITLE
feat: add accessibility settings with speech and screen reader

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Optional
+import platform
+import threading
 
 try:  # pragma: no cover - import may fail on headless systems
     import tkinter as tk  # type: ignore
@@ -32,6 +34,16 @@ try:  # pragma: no cover - optional dependency
     import qrcode  # type: ignore
 except Exception:  # pragma: no cover
     qrcode = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    import speech_recognition as sr  # type: ignore
+except Exception:  # pragma: no cover
+    sr = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    import pyttsx3  # type: ignore
+except Exception:  # pragma: no cover
+    pyttsx3 = None  # type: ignore[assignment]
 
 __all__ = ["ChatGUI", "DashboardManager", "main"]
 
@@ -106,7 +118,20 @@ class ChatGUI:
         self.scheduler = scheduler or EcoScheduler()
         self.updater = Updater()
 
+        # Accessibility
+        acc = self._detect_accessibility()
+        self.screen_reader_enabled = acc.get("screen_reader", False)
+        self.high_contrast_enabled = acc.get("high_contrast", False)
+        self.speech_enabled = False
+        self._tts = pyttsx3.init() if pyttsx3 else None
+        self._recognizer = sr.Recognizer() if sr else None
+        self._mic = sr.Microphone() if sr else None
+        self._sr_thread: threading.Thread | None = None
+
         self._build_widgets()
+
+        if self.high_contrast_enabled:
+            self._apply_high_contrast()
 
         # Allow external plugins to modify the GUI
         for plugin in get_plugins():  # pragma: no cover - runtime hook
@@ -198,6 +223,9 @@ class ChatGUI:
         ttk.Button(
             input_frame, text="Restore", command=self._restore_snapshot
         ).pack(side="left", padx=5)
+        ttk.Button(
+            input_frame, text="Accessibility", command=self._open_accessibility_settings
+        ).pack(side="left", padx=5)
 
     def _create_snapshot(self) -> None:
         """Create a system snapshot for later restoration."""
@@ -224,6 +252,116 @@ class ChatGUI:
         self.chat.insert("end", "[Optimization] Reverted profile\n")
         self.chat.see("end")
 
+    # -------------------------------------------------------- Accessibility
+    def _detect_accessibility(self) -> Dict[str, bool]:
+        """Inspect basic Windows accessibility settings."""
+        info = {"screen_reader": False, "high_contrast": False}
+        if platform.system() == "Windows":  # pragma: no cover - OS dependent
+            try:
+                import ctypes
+
+                SPI_GETSCREENREADER = 70
+                SPI_GETHIGHCONTRAST = 67
+
+                flag = ctypes.c_int()
+                if ctypes.windll.user32.SystemParametersInfoW(
+                    SPI_GETSCREENREADER, 0, ctypes.byref(flag), 0
+                ):
+                    info["screen_reader"] = bool(flag.value)
+
+                class HIGHCONTRAST(ctypes.Structure):
+                    _fields_ = [
+                        ("cbSize", ctypes.c_uint),
+                        ("dwFlags", ctypes.c_uint),
+                        ("lpszDefaultScheme", ctypes.c_wchar_p),
+                    ]
+
+                hc = HIGHCONTRAST()
+                hc.cbSize = ctypes.sizeof(HIGHCONTRAST)
+                if ctypes.windll.user32.SystemParametersInfoW(
+                    SPI_GETHIGHCONTRAST, hc.cbSize, ctypes.byref(hc), 0
+                ):
+                    info["high_contrast"] = bool(hc.dwFlags & 1)
+            except Exception:
+                pass
+        return info
+
+    def _apply_high_contrast(self) -> None:
+        """Apply a minimal high contrast theme to the chat widgets."""
+        self.root.configure(bg="black")
+        self.chat.configure(bg="black", fg="white")
+        self.entry.configure(bg="black", fg="white", insertbackground="white")
+
+    def _speak(self, text: str) -> None:
+        """Speak text when screen reader mode is enabled."""
+        if self.screen_reader_enabled and self._tts:
+            threading.Thread(
+                target=lambda: (self._tts.say(text), self._tts.runAndWait()),
+                daemon=True,
+            ).start()
+
+    def _listen_loop(self) -> None:
+        """Background speech recognition loop."""
+        if not (self._recognizer and self._mic):
+            return
+        while self.speech_enabled:
+            with self._mic as source:
+                audio = self._recognizer.listen(source)
+            try:
+                text = self._recognizer.recognize_google(audio)
+            except Exception:
+                text = ""
+            if text:
+                self.entry.insert("end", text + " ")
+
+    def _toggle_speech_recognition(self) -> None:
+        """Start or stop the speech recognition loop."""
+        if not self._recognizer or not self._mic:
+            return
+        self.speech_enabled = not self.speech_enabled
+        if self.speech_enabled:
+            self._sr_thread = threading.Thread(
+                target=self._listen_loop, daemon=True
+            )
+            self._sr_thread.start()
+
+    def _open_accessibility_settings(self) -> None:
+        """Allow enabling speech recognition and screen reader hooks."""
+        win = tk.Toplevel(self.root)
+        win.title("Accessibility")
+
+        sr_var = tk.BooleanVar(value=self.screen_reader_enabled)
+        sp_var = tk.BooleanVar(value=self.speech_enabled)
+        hc_var = tk.BooleanVar(value=self.high_contrast_enabled)
+
+        ttk.Checkbutton(win, text="Screen reader", variable=sr_var).grid(
+            row=0, column=0, sticky="w", padx=5, pady=5
+        )
+        ttk.Checkbutton(win, text="Speech input", variable=sp_var).grid(
+            row=1, column=0, sticky="w", padx=5, pady=5
+        )
+        ttk.Checkbutton(win, text="High contrast", variable=hc_var).grid(
+            row=2, column=0, sticky="w", padx=5, pady=5
+        )
+
+        def save() -> None:
+            self.screen_reader_enabled = sr_var.get()
+            if self.speech_enabled != sp_var.get():
+                self._toggle_speech_recognition()
+            self.high_contrast_enabled = hc_var.get()
+            if self.high_contrast_enabled:
+                self._apply_high_contrast()
+            else:
+                # simple reset by recreating widgets' colors
+                self.root.configure(bg="SystemButtonFace")
+                self.chat.configure(bg="white", fg="black")
+                self.entry.configure(bg="white", fg="black", insertbackground="black")
+            win.destroy()
+
+        ttk.Button(win, text="Save", command=save).grid(
+            row=3, column=0, padx=5, pady=5, sticky="e"
+        )
+
     # ------------------------------------------------------------- Scheduling
     def schedule_message(self) -> None:
         """Schedule the current entry text for the next off-peak window."""
@@ -237,10 +375,12 @@ class ChatGUI:
             response = backend.generate(prompt)
             self.chat.insert("end", f"[Off-peak] Bot: {response}\n")
             self.chat.see("end")
+            self._speak(f"Bot: {response}")
 
         self.scheduler.schedule(run)
         self.chat.insert("end", f"[Scheduled] {prompt}\n")
         self.chat.see("end")
+        self._speak(f"Scheduled {prompt}")
         self.entry.delete(0, "end")
 
     def _open_scheduler_settings(self) -> None:
@@ -493,10 +633,12 @@ class ChatGUI:
         if not prompt:
             return
         self.chat.insert("end", f"You: {prompt}\n")
+        self._speak(f"You: {prompt}")
         self.entry.delete(0, "end")
         backend = self.backends[self.backend_var.get()]
         response = backend.generate(prompt)
         self.chat.insert("end", f"Bot: {response}\n")
+        self._speak(f"Bot: {response}")
         self.chat.see("end")
 
     # ---------------------------------------------------------- Sync settings

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -24,5 +24,21 @@ handlers and alternative input devices.  Voice commands can be processed or
 translated into chat messages, and accessibility devices can inject text directly
 into the chat interface.
 
+### Chat GUI
+
+`control_center.gui.ChatGUI` detects whether Windows has a screen reader or
+high-contrast theme enabled and adjusts its defaults accordingly.  The chat
+window exposes an **Accessibility** panel where users can toggle:
+
+* **Screen reader narration** – speaks chat messages using the system
+  text-to-speech engine.
+* **Speech input** – captures microphone audio and inserts recognized text into
+  the message entry field.
+* **High contrast mode** – switches the chat window to a high contrast color
+  scheme.
+
+These options allow the interface to adapt to individual needs without
+requiring external tools.
+
 These features form the foundation for broader accessibility support and are
 intended to be extended by downstream applications.


### PR DESCRIPTION
## Summary
- detect Windows screen reader and high-contrast settings
- add accessibility panel with speech input and narration options
- document accessibility controls

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'zeroconf')*


------
https://chatgpt.com/codex/tasks/task_e_68b512c626d88326ab0683e9c5438018