### PR TITLE
Add eco monitor and settings

### DIFF
--- a/control_center/gui.py
+++ b/control_center/gui.py
@@ -25,6 +25,8 @@ from plugins.manager import PluginManager
 from security import AuditLogger, PermissionManager
 from optimization import tuning
 from eco.scheduler import EcoScheduler
+from eco.monitor import EcoMonitor
+from eco.tracker import PowerInfo
 from updater import Updater
 from installer import snapshot
 
@@ -81,6 +83,7 @@ class ChatGUI:
         root: Optional["tk.Tk"] = None,
         backends: Optional[Dict[str, Backend]] = None,
         scheduler: Optional[EcoScheduler] = None,
+        monitor: Optional[EcoMonitor] = None,
     ) -> None:
         if tk is None or ttk is None:
             raise RuntimeError("tkinter is not available")
@@ -104,6 +107,7 @@ class ChatGUI:
         self.permission_manager = PermissionManager(audit_logger=self.audit_logger)
         self.dashboard_manager = DashboardManager()
         self.scheduler = scheduler or EcoScheduler()
+        self.eco_monitor = monitor or EcoMonitor(scheduler=self.scheduler)
         self.updater = Updater()
 
         self._build_widgets()
@@ -187,6 +191,9 @@ class ChatGUI:
             input_frame, text="Defer", command=self.schedule_message
         ).pack(side="left", padx=5)
         ttk.Button(
+            input_frame, text="Eco", command=self._open_eco_settings
+        ).pack(side="left", padx=5)
+        ttk.Button(
             input_frame, text="Scheduler", command=self._open_scheduler_settings
         ).pack(side="left", padx=5)
         ttk.Button(
@@ -263,6 +270,36 @@ class ChatGUI:
 
         ttk.Button(win, text="Save", command=save).grid(
             row=2, column=0, columnspan=2, pady=5
+        )
+
+    def _open_eco_settings(self) -> None:
+        """Show current energy usage and scheduler options."""
+
+        win = tk.Toplevel(self.root)
+        win.title("Eco Settings")
+
+        def fmt(info: PowerInfo) -> str:
+            percent = f"{info.percent:.0f}%" if info.percent is not None else "n/a"
+            if info.secs_left is None or info.secs_left < 0:
+                left = "n/a"
+            else:
+                left = f"{info.secs_left // 60}m"
+            plugged = (
+                "yes"
+                if info.power_plugged
+                else "no" if info.power_plugged is not None else "n/a"
+            )
+            return f"Battery: {percent}\nTime left: {left}\nPlugged in: {plugged}"
+
+        label = ttk.Label(win, text=fmt(self.eco_monitor.sample()), justify="left")
+        label.pack(padx=5, pady=5)
+
+        def refresh() -> None:
+            label.config(text=fmt(self.eco_monitor.sample()))
+
+        ttk.Button(win, text="Refresh", command=refresh).pack(pady=5)
+        ttk.Button(win, text="Scheduler", command=self._open_scheduler_settings).pack(
+            pady=5
         )
 
     def _open_update_settings(self) -> None:

--- a/docs/eco.md
+++ b/docs/eco.md
@@ -1,0 +1,9 @@
+# Eco Monitor
+
+The `eco` package offers tools to minimize power consumption.  
+`EcoMonitor` combines `EnergyTracker` for battery readings with
+`EcoScheduler` which defers work to configurable off-peak windows.
+
+The Control Center exposes these features through **Eco Settings** where
+current power information can be inspected and scheduling windows
+adjusted.

--- a/eco/__init__.py
+++ b/eco/__init__.py
@@ -9,5 +9,6 @@ light‑weight and rely only on the Python standard library and optional
 from .tracker import EnergyTracker
 from .reports import generate_report
 from .scheduler import EcoScheduler
+from .monitor import EcoMonitor
 
-__all__ = ["EnergyTracker", "EcoScheduler", "generate_report"]
+__all__ = ["EnergyTracker", "EcoScheduler", "EcoMonitor", "generate_report"]

--- a/eco/monitor.py
+++ b/eco/monitor.py
@@ -1,0 +1,37 @@
+"""Energy usage monitoring with off-peak scheduling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from threading import Timer
+from typing import Callable, Optional
+
+from .tracker import EnergyTracker, PowerInfo
+from .scheduler import EcoScheduler
+
+
+@dataclass
+class EcoMonitor:
+    """Combine :class:`EnergyTracker` and :class:`EcoScheduler`.
+
+    The monitor keeps a small in-memory history of power readings and
+    exposes a convenience wrapper for scheduling callables during off-peak
+    hours.
+    """
+
+    tracker: EnergyTracker = field(default_factory=EnergyTracker)
+    scheduler: EcoScheduler = field(default_factory=EcoScheduler)
+    history: list[PowerInfo] = field(default_factory=list, init=False)
+
+    def sample(self) -> PowerInfo:
+        """Record and return the current power information."""
+
+        info = self.tracker.current()
+        self.history.append(info)
+        return info
+
+    def schedule(self, func: Callable[[], None], now: Optional[datetime] = None) -> Timer:
+        """Schedule ``func`` for the next off-peak window."""
+
+        return self.scheduler.schedule(func, now=now)

--- a/tests/test_eco_monitor.py
+++ b/tests/test_eco_monitor.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+import time
+
+from eco.monitor import EcoMonitor
+from eco.scheduler import EcoScheduler
+from eco.tracker import PowerInfo
+
+
+def test_sample_returns_power_info():
+    monitor = EcoMonitor()
+    info = monitor.sample()
+    assert isinstance(info, PowerInfo)
+
+
+def test_schedule_uses_scheduler():
+    calls: list[int] = []
+
+    def task() -> None:
+        calls.append(1)
+
+    sched = EcoScheduler(windows=[(0, 23)])
+    monitor = EcoMonitor(scheduler=sched)
+    monitor.schedule(task, now=datetime(2024, 1, 1, 1, 0))
+    time.sleep(0.1)
+    assert calls


### PR DESCRIPTION
## Summary
- integrate EcoMonitor to track power usage and schedule work during off-peak hours
- expose energy info and scheduler access via new Eco Settings window in Control Center
- document eco monitoring utilities

## Testing
- `pytest -q` *(fails: module 'installer.gui' has no attribute 'time'; no devices for zeroconf; models module lacks 'time'; missing DummyPsutil in task manager test)*

------
https://chatgpt.com/codex/tasks/task_e_68b512cf01a483268644515302921864