### PR TITLE
feat: document unified REST endpoints

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,6 +1,8 @@
 # Windows AI Actions API
 
-This API exposes system functionality such as shell commands, mesh networking, IoT events and search utilities. All endpoints accept and return JSON.
+The Windows AI platform exposes REST endpoints for local features. The interfaces are standardized in [openapi/windows-ai.yaml](../openapi/windows-ai.yaml) and are served from `http://localhost:3000`.
+
+All endpoints accept and return JSON.
 
 ## Endpoints
 

--- a/openapi/windows-ai.yaml
+++ b/openapi/windows-ai.yaml
@@ -1,1 +1,161 @@
-openapi: 3.1.0info:  title: Windows AI Actions API  version: 0.2.0paths:  /api/actions/execute:    post:      summary: Execute a system action      requestBody:        required: true        content:          application/json:            schema:              $ref: ../codex/SCHEMAS/actions.request.schema.json      responses:        "200":          description: Result          content:            application/json:              schema:                $ref: ../codex/SCHEMAS/actions.response.schema.json  /api/mobile/pair:    post:      summary: Create a pairing token for a mobile device      requestBody:        required: true        content:          application/json:            schema:              type: object              properties:                deviceId:                  type: string              required: [deviceId]      responses:        "200":          description: Pairing token          content:            application/json:              schema:                type: object                properties:                  ok:                    type: boolean                  token:                    type: string  /api/mobile/command:    post:      summary: Execute a command from a paired mobile device      requestBody:        required: true        content:          application/json:            schema:              type: object              properties:                token:                  type: string                action:                  type: string                params:                  type: object      responses:        "200":          description: Action result          content:            application/json:              schema:                type: object                properties:                  ok:                    type: boolean                  result:                    type: object  /api/mesh/distribute:    post:      summary: Distribute a task to mesh nodes      requestBody:        required: true        content:          application/json:            schema:              type: object              properties:                task:                  type: string              required: [task]      responses:        "200":          description: Distribution acknowledgement          content:            application/json:              schema:                type: object                properties:                  ok:                    type: boolean                  result:                    type: object                    properties:                      distributed:                        type: string  /api/iot/event:    post:      summary: Handle an IoT device event      requestBody:        required: true        content:          application/json:            schema:              type: object              properties:                deviceId:                  type: string                event:                  type: string              required: [deviceId, event]      responses:        "200":          description: Event acknowledgement          content:            application/json:              schema:                type: object                properties:                  ok:                    type: boolean                  result:                    type: object                    properties:                      deviceId:                        type: string                      event:                        type: string  /api/search/query:    post:      summary: Query a set of documents      requestBody:        required: true        content:          application/json:            schema:              type: object              properties:                query:                  type: string                documents:                  type: object                  additionalProperties:                    type: string              required: [query]      responses:        "200":          description: Matching document ids          content:            application/json:              schema:                type: object                properties:                  ok:                    type: boolean                  result:                    type: array                    items:                      type: string
+openapi: 3.1.0
+info:
+  title: Windows AI API
+  version: "1.0.0"
+servers:
+  - url: http://localhost:3000
+    description: Local development server
+paths:
+  /api/actions/execute:
+    post:
+      summary: Execute a named action on the host.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                action:
+                  type: string
+                params:
+                  type: object
+      responses:
+        "200":
+          description: Command result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  result:
+                    type: string
+  /api/mobile/pair:
+    post:
+      summary: Create a pairing token for a mobile device.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deviceId:
+                  type: string
+      responses:
+        "200":
+          description: Pairing token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  token:
+                    type: string
+  /api/mobile/command:
+    post:
+      summary: Execute an action on behalf of a paired device.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                action:
+                  type: string
+      responses:
+        "200":
+          description: Action result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  result:
+                    type: string
+  /api/mesh/distribute:
+    post:
+      summary: Distribute a task to mesh nodes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                task:
+                  type: string
+      responses:
+        "200":
+          description: Distribution result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  result:
+                    type: string
+  /api/iot/event:
+    post:
+      summary: Submit an IoT device event.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                deviceId:
+                  type: string
+                event:
+                  type: string
+      responses:
+        "200":
+          description: Event acknowledgment
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+  /api/search/query:
+    post:
+      summary: Query a set of documents and return matching ids.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                documents:
+                  type: object
+      responses:
+        "200":
+          description: Query results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  result:
+                    type: array
+                    items:
+                      type: string
+components: {}


### PR DESCRIPTION
## Summary
- standardize Windows AI REST API in openapi spec
- document available endpoints in developer reference

## Testing
- `npm test` *(fails: Cannot find module '/workspace/Windows-AI/tests/run.mjs')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b512eb09208326b5ad566b1aaf9a68