### PR TITLE
feat: add configuration snapshot utilities

### DIFF
--- a/docs/rollback.md
+++ b/docs/rollback.md
@@ -1,12 +1,27 @@
-# Rollback and Uninstall
+# Rollback and Snapshot Removal
 
-Windows AI records the system changes performed during installation so that they can be undone later.
+The installer and updater capture configuration snapshots before modifying
+system files. Each snapshot is associated with a feature name and stored in
+`~/.windows_ai/snapshots`.
 
-## Snapshots
+## Rolling back
 
-Running the installer creates a snapshot file under `~/.windows_ai/` that lists the services and firewall rules added by the setup process.
-Use the Control Center's **Snapshot** button to manually create a snapshot before making further changes and **Restore** to revert the environment.
+When an installation or update fails, the modules restore the affected feature
+from its snapshot:
 
-## Uninstall
+```python
+from snapshot import rollback
+rollback("install")
+```
 
-The `install/uninstall.ps1` script reads the snapshot and removes any recorded services and firewall rules, returning the machine to its previous state.
+## Removing snapshots
+
+Successful operations automatically remove their snapshots. Snapshots can also
+be removed manually:
+
+```python
+from snapshot import remove
+remove("install")
+```
+
+Deleting the `snapshots` directory will remove all stored backups.

--- a/installer/__init__.py
+++ b/installer/__init__.py
@@ -1,1 +1,5 @@
 """Prototype installer package for Windows AI ecosystem."""
+
+from . import snapshot
+
+__all__ = ["snapshot"]

--- a/installer/snapshot.py
+++ b/installer/snapshot.py
@@ -16,6 +16,9 @@ import logging
 import shutil
 from typing import Set
 
+from snapshot import capture as capture_config
+from snapshot import rollback as rollback_config
+
 # Location of the snapshot record
 CONFIG_DIR = Path.home() / ".windows_ai"
 SNAPSHOT_FILE = CONFIG_DIR / "snapshot.json"
@@ -139,6 +142,22 @@ def load_snapshot() -> Snapshot:
     return Snapshot.load()
 
 
+def snapshot_config(feature: str, path: Path | str) -> None:
+    """Capture configuration at ``path`` for ``feature``.
+
+    This delegates to :mod:`snapshot`'s :func:`capture` helper so that the
+    installer can restore individual features if a later step fails.
+    """
+
+    capture_config(feature, path)
+
+
+def rollback_feature(feature: str) -> None:
+    """Roll back configuration for ``feature`` using stored snapshots."""
+
+    rollback_config(feature)
+
+
 __all__ = [
     "Snapshot",
     "SNAPSHOT_FILE",
@@ -148,6 +167,8 @@ __all__ = [
     "record_firewall_rule",
     "restore",
     "load_snapshot",
+    "snapshot_config",
+    "rollback_feature",
 ]
 
 

--- a/snapshot/__init__.py
+++ b/snapshot/__init__.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Configuration snapshot utilities for per-feature rollback.
+
+This lightweight module stores copies of configuration files or directories
+before they are modified. Each snapshot is keyed by a feature name allowing
+individual rollback without affecting unrelated components.
+"""
+
+from pathlib import Path
+import json
+import shutil
+
+
+SNAPSHOT_DIR = Path.home() / ".windows_ai" / "snapshots"
+INDEX_FILE = SNAPSHOT_DIR / "index.json"
+
+
+def _load_index() -> dict[str, str]:
+    if INDEX_FILE.exists():
+        try:
+            return json.loads(INDEX_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_index(index: dict[str, str]) -> None:
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    INDEX_FILE.write_text(json.dumps(index, indent=2))
+
+
+def capture(feature: str, path: Path | str) -> Path:
+    """Capture the current state of ``path`` for ``feature``.
+
+    Any existing snapshot for the feature is replaced. A copy of ``path`` is
+    stored inside :data:`SNAPSHOT_DIR` and the original location is recorded in
+    an index file so that :func:`rollback` knows where to restore it.
+    """
+
+    path = Path(path)
+    dest = SNAPSHOT_DIR / feature
+    if dest.exists():
+        if dest.is_dir():
+            shutil.rmtree(dest)
+        else:
+            dest.unlink()
+    if path.exists():
+        if path.is_dir():
+            shutil.copytree(path, dest)
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, dest)
+    else:
+        dest.mkdir(parents=True, exist_ok=True)
+    index = _load_index()
+    index[feature] = str(path)
+    _save_index(index)
+    return dest
+
+
+def rollback(feature: str) -> None:
+    """Restore the configuration snapshot for ``feature`` if it exists."""
+
+    index = _load_index()
+    target = Path(index.get(feature, ""))
+    backup = SNAPSHOT_DIR / feature
+    if not backup.exists() or not target:
+        return
+    if target.exists():
+        if target.is_dir():
+            shutil.rmtree(target)
+        else:
+            target.unlink()
+    if backup.is_dir():
+        shutil.copytree(backup, target, dirs_exist_ok=True)
+    else:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(backup, target)
+
+
+def remove(feature: str) -> None:
+    """Remove snapshot data for ``feature`` without restoring it."""
+
+    backup = SNAPSHOT_DIR / feature
+    if backup.exists():
+        if backup.is_dir():
+            shutil.rmtree(backup)
+        else:
+            backup.unlink()
+    index = _load_index()
+    if feature in index:
+        del index[feature]
+        _save_index(index)
+
+
+__all__ = ["capture", "rollback", "remove", "SNAPSHOT_DIR"]

--- a/updater/__init__.py
+++ b/updater/__init__.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 from pathlib import Path
 import hashlib
-import shutil
 import subprocess
-import tempfile
 from typing import Callable
 from urllib.request import urlopen
+
+from snapshot import capture as snapshot_capture
+from snapshot import rollback as snapshot_rollback
+from snapshot import remove as snapshot_remove
 
 __all__ = ["Updater"]
 
@@ -150,26 +152,24 @@ class Updater:
 
     # ------------------------------------------------------------------
     # Snapshot and rollback
-    def _snapshot_path(self) -> Path:
-        return Path(tempfile.mkdtemp(prefix="waisnap_"))
+    def _feature(self) -> str:
+        """Return the snapshot feature name for this installation."""
+
+        return "install"
 
     def create_snapshot(self) -> Path:
-        """Create a snapshot of the install directory and return it."""
+        """Capture a snapshot of the install directory and return its path."""
 
-        snap = self._snapshot_path()
-        if self.install_dir.exists():
-            shutil.copytree(self.install_dir, snap / "install", dirs_exist_ok=True)
-        return snap
+        return snapshot_capture(self._feature(), self.install_dir)
 
-    def rollback(self, snapshot: Path) -> None:
-        """Restore the install directory from *snapshot*."""
+    def rollback(self, snapshot: Path | None = None) -> None:
+        """Restore the install directory from the stored snapshot."""
 
         try:
             self.run_uninstall()
         finally:
-            if self.install_dir.exists():
-                shutil.rmtree(self.install_dir)
-            shutil.copytree(snapshot / "install", self.install_dir, dirs_exist_ok=True)
+            snapshot_rollback(self._feature())
+            snapshot_remove(self._feature())
 
     # ------------------------------------------------------------------
     # Installation helpers
@@ -208,6 +208,7 @@ class Updater:
         snapshot = self.create_snapshot()
         try:
             self.run_install(package_path)
+            snapshot_remove(self._feature())
         except Exception:
             self.rollback(snapshot)
             raise


### PR DESCRIPTION
## Summary
- add snapshot package for per-feature configuration backups
- integrate snapshots into installer and updater modules
- document snapshot cleanup procedures

## Testing
- `pre-commit run --files snapshot/__init__.py installer/__init__.py installer/snapshot.py updater/__init__.py docs/rollback.md` *(fails: InvalidConfigError)*
- `pytest tests/test_snapshot_lifecycle.py tests/test_updater_rollback.py`


------
https://chatgpt.com/codex/tasks/task_e_68b512f6a7c0832683c5ed6ae23390f0