### PR TITLE
Ensure Python detection preserves runtime flags

### DIFF
--- a/tests/_util.mjs
+++ b/tests/_util.mjs
@@ -1,15 +1,34 @@
 import { spawnSync } from 'child_process';
-export function detectPython(){
-  const candidates = [
-    {cmd:'python', args:['--version']},
-    {cmd:'python3', args:['--version']},
-    {cmd:'py', args:['-3','--version']},
-  ];
-  for (const c of candidates){
-    const r = spawnSync(c.cmd, c.args, {encoding:'utf8'});
-    if (r.status === 0 || (r.stdout && r.stdout.includes('Python')) || (r.stderr && r.stderr.includes('Python'))) {
-      return c;
+
+const CANDIDATES = [
+  {
+    cmd: 'python',
+    runArgs: [],
+    detectArgs: ['--version'],
+  },
+  {
+    cmd: 'python3',
+    runArgs: [],
+    detectArgs: ['--version'],
+  },
+  {
+    cmd: 'py',
+    runArgs: ['-3'],
+    detectArgs: ['-3', '--version'],
+  },
+];
+
+export function detectPython() {
+  for (const candidate of CANDIDATES) {
+    const result = spawnSync(candidate.cmd, candidate.detectArgs, { encoding: 'utf8' });
+    if (
+      result.status === 0 ||
+      (result.stdout && result.stdout.includes('Python')) ||
+      (result.stderr && result.stderr.includes('Python'))
+    ) {
+      return { cmd: candidate.cmd, args: candidate.runArgs };
     }
   }
+
   return { cmd: 'python', args: [] };
 }

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -1,0 +1,28 @@
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { detectPython } from './_util.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const python = detectPython();
+const extraArgs = process.argv.slice(2);
+const pytestArgs = [...python.args, '-m', 'pytest', ...extraArgs];
+
+const result = spawnSync(python.cmd, pytestArgs, {
+  cwd: repoRoot,
+  stdio: 'inherit'
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+if (typeof result.status === 'number') {
+  process.exit(result.status);
+}
+
+process.exit(1);


### PR DESCRIPTION
## Summary
- preserve required runtime arguments for detected Python commands while still keeping detection-specific flags separate

## Testing
- npm test -- --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68f2975dc7ec832683504189121ab86e