### PR TITLE
Improve Python detection robustness

### DIFF
--- a/tests/_util.mjs
+++ b/tests/_util.mjs
@@ -1,15 +1,121 @@
+
 import { spawnSync } from 'child_process';
-export function detectPython(){
-  const candidates = [
-    {cmd:'python', args:['--version']},
-    {cmd:'python3', args:['--version']},
-    {cmd:'py', args:['-3','--version']},
+
+const DEFAULT_CANDIDATES = [
+  {
+    cmd: 'python',
+    runArgs: [],
+    detectArgs: ['--version'],
+  },
+  {
+    cmd: 'python3',
+    runArgs: [],
+    detectArgs: ['--version'],
+  },
+  {
+    cmd: 'py',
+    runArgs: ['-3'],
+    detectArgs: ['-3', '--version'],
+  },
+];
+
+function splitCommandLine(spec) {
+  const segments = [];
+  let current = '';
+  let quote = null;
+  let escape = false;
+
+  for (const ch of spec) {
+    if (escape) {
+      current += ch;
+      escape = false;
+      continue;
+    }
+
+    if (ch === '\\' && quote !== "'") {
+      escape = true;
+      continue;
+    }
+
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+
+    if (!quote && /\s/.test(ch)) {
+      if (current) {
+        segments.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (escape) {
+    current += '\\';
+  }
+
+  if (current) {
+    segments.push(current);
+  }
+
+  return segments;
+}
+
+function resolveCandidates() {
+  const envCmd = process.env.PYTHON?.trim();
+  if (!envCmd) {
+    return DEFAULT_CANDIDATES;
+  }
+
+  const [cmd, ...args] = splitCommandLine(envCmd);
+  if (!cmd) {
+    return DEFAULT_CANDIDATES;
+  }
+
+  return [
+    {
+      cmd,
+      runArgs: args,
+      detectArgs: [...args, '--version'],
+    },
+    ...DEFAULT_CANDIDATES,
   ];
-  for (const c of candidates){
-    const r = spawnSync(c.cmd, c.args, {encoding:'utf8'});
-    if (r.status === 0 || (r.stdout && r.stdout.includes('Python')) || (r.stderr && r.stderr.includes('Python'))) {
-      return { cmd: c.cmd, args: [] };
+}
+
+function isPythonCandidate(candidate) {
+  const result = spawnSync(candidate.cmd, candidate.detectArgs, { encoding: 'utf8' });
+
+  if (result.error) {
+    return false;
+  }
+
+  if (typeof result.status === 'number' && result.status !== 0) {
+    return false;
+  }
+
+  const combinedOutput = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  return /Python/i.test(combinedOutput);
+}
+
+export function detectPython() {
+  for (const candidate of resolveCandidates()) {
+    if (isPythonCandidate(candidate)) {
+      return { cmd: candidate.cmd, args: [...candidate.runArgs] };
     }
   }
+
   return { cmd: 'python', args: [] };
 }
+


### PR DESCRIPTION
## Summary
- allow overriding the detected Python command via the PYTHON environment variable
- require a successful probe before selecting a Python candidate and surface runtime args safely

## Testing
- npm test -- --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68f2975dc7ec832683504189121ab86e