### PR TITLE
Add Zeroconf adapter pairing logic and tests

### DIFF
--- a/iot/adapters/zeroconf.py
+++ b/iot/adapters/zeroconf.py
@@ -35,3 +35,7 @@ class ZeroconfAdapter(DeviceAdapter):
             zc.close()
 
         return devices
+
+    def pair(self, device: Device) -> bool:
+        """Only allow pairing for devices discovered via Zeroconf."""
+        return device.protocol == self.protocol

--- a/tests/test_iot_discovery.py
+++ b/tests/test_iot_discovery.py
@@ -4,24 +4,17 @@ from iot import ADAPTERS, Device, discover_devices, pair_device
 
 
 def _mock_zeroconf(monkeypatch):
-    import zeroconf
-
-    class FakeInfo:
-        name = "ZCDevice._http._tcp.local."
-        properties = {b"id": b"zc-1"}
+    import iot.adapters.zeroconf as zc
 
     class FakeZeroconf:
-        def get_service_info(self, type_, name):
-            return FakeInfo()
-
         def close(self):
             pass
 
-    def fake_service_browser(zc, stype, listener):
-        listener.add_service(zc, stype, FakeInfo().name)
+    def fake_service_browser(zc_instance, service_type, listener):
+        listener.add_service(zc_instance, service_type, "ZCDevice._http._tcp.local.")
 
-    monkeypatch.setattr(zeroconf, "Zeroconf", lambda: FakeZeroconf())
-    monkeypatch.setattr(zeroconf, "ServiceBrowser", fake_service_browser)
+    monkeypatch.setattr(zc, "Zeroconf", lambda: FakeZeroconf())
+    monkeypatch.setattr(zc, "ServiceBrowser", fake_service_browser)
 
 
 def test_discover_devices_returns_devices(monkeypatch):

--- a/tests/test_zeroconf_adapter.py
+++ b/tests/test_zeroconf_adapter.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from iot import Device, pair_device
 from iot.adapters.zeroconf import ZeroconfAdapter
 
 
@@ -20,4 +21,7 @@ def test_zeroconf_discover_simulated_devices():
     assert device.id == "TestDevice._http._tcp.local."
     assert device.name == "TestDevice"
     assert device.protocol == adapter.protocol
+    assert pair_device("zeroconf", device) is True
+    wrong = Device(id="x", name="x", protocol="other")
+    assert pair_device("zeroconf", wrong) is False
     zc_instance.close.assert_called_once()


### PR DESCRIPTION
## Summary
- validate device protocol before pairing in ZeroconfAdapter
- test simulated Zeroconf discovery and pairing logic

## Testing
- `pytest tests/test_zeroconf_adapter.py tests/test_iot_discovery.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5132e0320832681b5ca1a74e4a1e6