### PR TITLE
Collect process metrics for TaskManagerAI

### DIFF
--- a/tests/test_task_manager_ai.py
+++ b/tests/test_task_manager_ai.py
@@ -10,19 +10,15 @@ class DummyModel:
 
 
 def test_analyze_processes_records_prompt(monkeypatch):
+    class FakeProcess:
+        def __init__(self, name, cpu, mem):
+            self.info = {
+                "name": name,
+                "cpu_percent": cpu,
+                "memory_info": SimpleNamespace(rss=mem),
+            }
+
     def fake_process_iter(attrs=None):
-        class FakeProcess:
-            def __init__(self, name, cpu, mem):
-                self.info = {"name": name}
-                self._cpu = cpu
-                self._mem = mem
-
-            def cpu_percent(self, interval=None):
-                return self._cpu
-
-            def memory_info(self):
-                return SimpleNamespace(rss=self._mem)
-
         yield FakeProcess("proc1", 10.0, 100 * 1024 * 1024)
         yield FakeProcess("proc2", 20.0, 200 * 1024 * 1024)
 
@@ -31,13 +27,10 @@ def test_analyze_processes_records_prompt(monkeypatch):
 
     model = DummyModel()
     tm = TaskManagerAI(model)
-    # Stub psutil so metrics are deterministic
-    monkeypatch.setattr("windows_ai.task_manager.psutil", DummyPsutil())
+
     result = tm.analyze_processes(["proc1", "proc2"])
-    expected = (
-        "analyze: proc1 (cpu=10.0%, mem=100.0MB), "
-        "proc2 (cpu=20.0%, mem=200.0MB)"
+    expected_prompt = (
+        "analyze: proc1 (cpu=10.0%, mem=100.0MB), proc2 (cpu=20.0%, mem=200.0MB)"
     )
-    expected_prompt = "".join(expected)
     assert result == f"ANALYSIS:{expected_prompt}"
     assert tm.get_queries() == [expected_prompt]

--- a/windows_ai/task_manager.py
+++ b/windows_ai/task_manager.py
@@ -15,26 +15,38 @@ class TaskManagerAI:
         self._queries: List[str] = []
 
     def analyze_processes(self, processes: List[str]) -> str:
-        """Return model analysis for the provided process names."""
+        """Return model analysis for the provided process names.
+
+        For each requested ``process`` a tuple of ``(cpu, memory)`` usage is
+        collected via :mod:`psutil`.  CPU usage is reported as a percentage and
+        memory usage is reported in megabytes.  The metrics are embedded into
+        the prompt that is passed to the model.
+        """
 
         metrics: Dict[str, Tuple[float, float]] = {}
         try:
-            for proc in psutil.process_iter(["name"]):
+            # Gather CPU and memory information in a single iteration to reduce
+            # psutil overhead.
+            for proc in psutil.process_iter(["name", "cpu_percent", "memory_info"]):
                 name = proc.info.get("name")
                 if name in processes and name not in metrics:
+                    info = proc.info
                     try:
-                        cpu = proc.cpu_percent(interval=None)
-                        mem = proc.memory_info().rss / (1024 * 1024)
-                    except Exception:
+                        cpu = float(info.get("cpu_percent") or 0.0)
+                    except Exception:  # pragma: no cover - defensive
                         cpu = 0.0
+                    try:
+                        mem_info = info.get("memory_info")
+                        mem = float(mem_info.rss) / (1024 * 1024) if mem_info else 0.0
+                    except Exception:  # pragma: no cover - defensive
                         mem = 0.0
                     metrics[name] = (cpu, mem)
                     if len(metrics) == len(processes):
                         break
-        except Exception:
+        except Exception:  # pragma: no cover - psutil may raise AccessDenied
             pass
 
-        details = []
+        details: List[str] = []
         for name in processes:
             cpu, mem = metrics.get(name, (0.0, 0.0))
             details.append(f"{name} (cpu={cpu:.1f}%, mem={mem:.1f}MB)")


### PR DESCRIPTION
## Summary
- enrich TaskManagerAI with CPU and memory statistics for each process and embed metrics into model prompt
- add tests that stub psutil and verify metrics are captured and recorded

## Testing
- `pre-commit run --files windows_ai/task_manager.py tests/test_task_manager_ai.py` *(fails: InvalidConfigError)*
- `pytest tests/test_task_manager_ai.py -q`
- `pytest -q` *(fails: module and attribute errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b51332e8e48326aeace0634728582d