### PR TITLE
feat: add plugin uninstall support

### DIFF
--- a/plugins/manager.py
+++ b/plugins/manager.py
@@ -189,19 +189,21 @@ class PluginManager:
             raise ValueError("Cyclic dependency detected")
         _stack.add(plugin.name)
 
-        # Remove dependencies first when no other installed plugin requires them
+        # Gather dependencies that are still required by other installed plugins.
+        dependents: set[str] = set()
+        for other in self._installed:
+            if other == plugin.name:
+                continue
+            other_plugin = self.get_plugin(other)
+            if other_plugin:
+                dependents.update(other_plugin.dependencies)
+
+        # Remove dependencies when no other plugin depends on them
         for dep_name in plugin.dependencies:
             dep = self.get_plugin(dep_name)
             if dep is None:
                 raise ValueError(f"Missing dependency: {dep_name}")
-
-            # Determine if another plugin still depends on this dependency
-            shared = any(
-                dep_name in (self.get_plugin(other).dependencies if self.get_plugin(other) else [])
-                for other in self._installed
-                if other != plugin.name
-            )
-            if not shared:
+            if dep_name not in dependents:
                 self.uninstall(dep, messagebox, _stack)
 
         _stack.remove(plugin.name)

--- a/tests/test_plugin_uninstall.py
+++ b/tests/test_plugin_uninstall.py
@@ -63,3 +63,22 @@ def test_uninstall_keeps_shared_dependency(monkeypatch):
 
     assert calls == [["pip", "uninstall", "main1", "-y"]]
     assert manager._installed == {"Dep", "Main2"}
+
+
+def test_uninstall_noop_when_not_installed(monkeypatch):
+    """Uninstalling a plugin that was never installed should do nothing."""
+
+    plugin = make_plugin("Ghost")
+    manager = PluginManager()
+    manager.plugins = [plugin]
+
+    calls = []
+
+    def fake_run(args, shell, check, cwd, env):
+        calls.append(args)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    manager.uninstall(plugin)
+
+    assert calls == []
+    assert manager._installed == set()


### PR DESCRIPTION
## Summary
- add recursive plugin uninstall logic that cleans up unused dependencies
- test uninstall behaviour and dependency handling

## Testing
- `pre-commit run --files plugins/manager.py tests/test_plugin_uninstall.py` *(fails: InvalidConfigError: block sequence entries are not allowed in this context)*
- `pytest tests/test_plugin_uninstall.py`


------
https://chatgpt.com/codex/tasks/task_e_68b51349e9108326b3b4def5b8f01546