### PR TITLE
feat: add HMAC stream cipher and filesystem round-trip tests

### DIFF
--- a/cloud_sync/__init__.py
+++ b/cloud_sync/__init__.py
@@ -59,12 +59,24 @@ def _derive_key(password: str) -> bytes:
     return hashlib.sha256(password.encode()).digest()
 
 
+def _keystream(key: bytes, iv: bytes, length: int) -> bytes:
+    """Generate a pseudo-random keystream via HMAC-SHA256."""
+
+    out = bytearray()
+    counter = 0
+    while len(out) < length:
+        ctr = counter.to_bytes(4, "big")
+        out.extend(hmac.new(key, iv + ctr, hashlib.sha256).digest())
+        counter += 1
+    return bytes(out[:length])
+
+
 def encrypt(data: bytes, password: str) -> bytes:
-    """Encrypt ``data`` with ``password`` using XOR and HMAC authentication."""
+    """Encrypt ``data`` with ``password`` using a stream cipher and HMAC."""
 
     key = _derive_key(password)
     iv = os.urandom(16)
-    keystream = hashlib.sha256(iv + key).digest()
+    keystream = _keystream(key, iv, len(data))
     ciphertext = _xor(data, keystream)
     mac = hmac.new(key, iv + ciphertext, hashlib.sha256).digest()
     return iv + mac + ciphertext
@@ -80,7 +92,7 @@ def decrypt(data: bytes, password: str) -> bytes:
     expected = hmac.new(key, iv + ciphertext, hashlib.sha256).digest()
     if not hmac.compare_digest(mac, expected):
         raise ValueError("integrity check failed")
-    keystream = hashlib.sha256(iv + key).digest()
+    keystream = _keystream(key, iv, len(ciphertext))
     return _xor(ciphertext, keystream)
 
 

--- a/tests/test_cloud_sync.py
+++ b/tests/test_cloud_sync.py
@@ -52,8 +52,8 @@ def test_filesystem_provider_round_trip(tmp_path):
     provider = FilesystemProvider(tmp_path / "storage")
     sync = CloudSync(provider, "pw")
     local = tmp_path / "data.txt"
-    local.write_text("hello")
+    local.write_text("hello" * 20)
     sync.backup_file(local, "data")
     local.unlink()
     assert sync.restore_file(local, "data")
-    assert local.read_text() == "hello"
+    assert local.read_text() == "hello" * 20


### PR DESCRIPTION
## Summary
- strengthen cloud sync encryption with an HMAC-based keystream and integrity check
- exercise long-file round trip through FilesystemProvider

## Testing
- `pytest tests/test_cloud_sync.py::test_decrypt_integrity_failure -q`
- `pytest tests/test_cloud_sync.py::test_filesystem_provider_round_trip -q`
- `pytest tests/test_cloud_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5134b9e508326afe3b82025685241