### PR TITLE
Add heartbeat and reconnection logic for mesh nodes

### DIFF
--- a/mesh/hub.py
+++ b/mesh/hub.py
@@ -45,6 +45,7 @@ class MeshHub:
 
         # Discovery UDP socket
         self._discovery_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._discovery_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self._discovery_sock.bind((self.host, self.discovery_port))
         self.discovery_port = self._discovery_sock.getsockname()[1]
         self._discovery_thread = threading.Thread(
@@ -54,6 +55,7 @@ class MeshHub:
 
         # TCP server for node connections
         self._server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self._server_sock.bind((self.host, self.port))
         self.port = self._server_sock.getsockname()[1]
         self._server_sock.listen()
@@ -174,47 +176,7 @@ class MeshHub:
                         conn.close()
                     except Exception:
                         pass
-                    del self._nodes[conn]
-
-    # ----------------------------------------------------------- heartbeat
-    def _node_listener(self, conn: socket.socket) -> None:
-        while self._running:
-            try:
-                header = conn.recv(4)
-                if not header:
-                    break
-                length = int.from_bytes(header, "big")
-                data = b""
-                while len(data) < length:
-                    chunk = conn.recv(length - len(data))
-                    if not chunk:
-                        break
-                    data += chunk
-                if len(data) != length:
-                    break
-                if self.protocol.decrypt(data) == b"HB":
-                    with self._lock:
-                        if conn in self._nodes:
-                            self._nodes[conn] = time.time()
-            except OSError:
-                break
-        with self._lock:
-            self._nodes.pop(conn, None)
-        try:
-            conn.close()
-        except Exception:
-            pass
-
-    def _prune_loop(self) -> None:
-        while self._running:
-            time.sleep(1)
-            now = time.time()
-            with self._lock:
-                for conn, ts in list(self._nodes.items()):
-                    if now - ts > self._timeout:
-                        try:
-                            conn.close()
-                        except Exception:
-                            pass
-                        del self._nodes[conn]
+                    if conn in self._nodes:
+                        self._nodes.remove(conn)
+                    self._last_heartbeat.pop(conn, None)
 

--- a/mesh/node.py
+++ b/mesh/node.py
@@ -52,41 +52,57 @@ class MeshNode:
         """Connect to the hub at *addr*."""
 
         self._addr = addr
-        self._sock = socket.create_connection(addr)
         self._running = True
-        self._thread = threading.Thread(target=self._listen, daemon=True)
+        # Background thread handles listening and reconnection attempts
+        self._thread = threading.Thread(
+            target=self._listen_loop, daemon=True
+        )
         self._thread.start()
+        # Separate heartbeat thread periodically pings the hub
         self._heartbeat_thread = threading.Thread(
             target=self._heartbeat_loop, daemon=True
         )
         self._heartbeat_thread.start()
 
-    def _listen(self) -> None:
+    def _listen_loop(self) -> None:
+        """Listen for tasks and reconnect if the connection drops."""
+
         while self._running:
-            sock = self._sock
-            if sock is None:
+            if self._sock is None:
                 if not self._reconnect():
-                    break
-                continue
+                    time.sleep(self.reconnect_interval)
+                    continue
             try:
-                header = sock.recv(4)
-                if not header:
-                    raise OSError
-                length = int.from_bytes(header, "big")
-                data = b""
-                while len(data) < length:
-                    chunk = sock.recv(length - len(data))
-                    if not chunk:
-                        raise OSError
-                    data += chunk
-                message = self.protocol.decrypt(data).decode()
-                self.handle_task(message)
+                self._listen()
             except OSError:
-                try:
-                    sock.close()
-                except Exception:
-                    pass
+                pass
+            finally:
+                # ensure socket is closed so that reconnect can occur
+                sock = self._sock
+                if sock is not None:
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
                 self._sock = None
+
+    def _listen(self) -> None:
+        sock = self._sock
+        if sock is None:
+            raise OSError
+        while self._running:
+            header = sock.recv(4)
+            if not header:
+                raise OSError
+            length = int.from_bytes(header, "big")
+            data = b""
+            while len(data) < length:
+                chunk = sock.recv(length - len(data))
+                if not chunk:
+                    raise OSError
+                data += chunk
+            message = self.protocol.decrypt(data).decode()
+            self.handle_task(message)
 
     def stop(self) -> None:
         self._running = False

--- a/tests/test_mesh_reconnect.py
+++ b/tests/test_mesh_reconnect.py
@@ -1,32 +1,78 @@
+"""Tests for MeshNode reconnection and hub pruning."""
+
+from __future__ import annotations
+
+import socket
 import time
 
 from mesh import MeshHub, MeshNode
 
 
-def test_node_reconnects_and_hub_prunes():
+def test_node_reconnects_after_hub_restart() -> None:
+    """Node should reconnect to the hub after the hub restarts."""
+
     key = b"k" * 32
     hub = MeshHub(key=key, heartbeat_timeout=0.3, prune_interval=0.1)
     hub.start()
 
     received: list[str] = []
-
-    node = MeshNode(received.append, key=key, heartbeat_interval=0.1, reconnect_interval=0.1)
-    node.connect(("127.0.0.1", hub.port))
+    node = MeshNode(
+        received.append,
+        key=key,
+        heartbeat_interval=0.1,
+        reconnect_interval=0.1,
+    )
+    node.connect((hub.host, hub.port))
+    # allow initial connection to establish
     time.sleep(0.2)
 
-    # simulate connection drop from hub side
-    with hub._lock:
-        conn = hub._nodes[0]
-    conn.close()
+    hub.distribute_task("one")
+    for _ in range(20):
+        if received:
+            break
+        time.sleep(0.1)
+    assert received == ["one"]
 
-    # allow time for pruning and reconnection
-    time.sleep(0.6)
+    # simulate hub going down and back up
+    hub.stop()
+    time.sleep(0.3)
+    hub.start()
+    # wait for node to reconnect
+    for _ in range(20):
+        with hub._lock:
+            if hub._nodes:
+                break
+        time.sleep(0.1)
 
-    hub.distribute_task("again")
-    time.sleep(0.2)
-
-    assert "again" in received
-    assert len(hub._nodes) == 1
+    hub.distribute_task("two")
+    for _ in range(50):
+        if len(received) == 2:
+            break
+        time.sleep(0.1)
+    assert received == ["one", "two"]
 
     node.stop()
     hub.stop()
+
+
+def test_hub_prunes_inactive_connection() -> None:
+    """Hub should remove connections that stop sending heartbeats."""
+
+    key = b"k" * 32
+    hub = MeshHub(key=key, heartbeat_timeout=0.2, prune_interval=0.05)
+    hub.start()
+
+    sock = socket.create_connection((hub.host, hub.port))
+    # The connection never sends heartbeats; wait for it to be pruned
+    for _ in range(20):
+        with hub._lock:
+            if not hub._nodes:
+                break
+        time.sleep(0.1)
+
+    with hub._lock:
+        assert not hub._nodes
+
+    sock.close()
+    hub.stop()
+


### PR DESCRIPTION
## Summary
- Add background heartbeat and reconnection handling to `MeshNode`
- Prune inactive nodes and allow socket reuse in `MeshHub`
- Add tests covering reconnection and heartbeat pruning

## Testing
- `pre-commit run --files mesh/node.py mesh/hub.py tests/test_mesh_reconnect.py` *(fails: InvalidConfigError: block sequence entries are not allowed in this context)*
- `pytest tests/test_mesh_reconnect.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5134da43483268893497987dae4a1