### PR TITLE
feat: support unregister result

### DIFF
--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -19,9 +19,13 @@ def test_register_and_unregister_callbacks():
     assert called == ["gesture", "voice"]
 
     # Unregister callbacks and ensure they are not invoked
-    mgr.unregister_gesture("swipe_left")
+    assert mgr.unregister_gesture("swipe_left") is True
     # Unregister with different casing to ensure case-insensitive removal
-    mgr.unregister_voice_command("HELLO")
+    assert mgr.unregister_voice_command("HELLO") is True
+
+    # Subsequent unregister calls should report nothing removed
+    assert mgr.unregister_gesture("swipe_left") is False
+    assert mgr.unregister_voice_command("hello") is False
 
     assert mgr.handle_gesture("swipe_left") is False
     assert mgr.handle_voice_command("hello") is False

--- a/tests/test_xr_input_manager.py
+++ b/tests/test_xr_input_manager.py
@@ -41,8 +41,12 @@ def test_unregister_callbacks():
     mgr.handle_voice_command("hello")
     assert called == ["swipe", "hello"]
 
-    mgr.unregister_gesture("swipe_left")
-    mgr.unregister_voice_command("hello")
+    assert mgr.unregister_gesture("swipe_left") is True
+    assert mgr.unregister_voice_command("hello") is True
+
+    # Second unregister should indicate nothing removed
+    assert mgr.unregister_gesture("swipe_left") is False
+    assert mgr.unregister_voice_command("hello") is False
 
     assert mgr.handle_gesture("swipe_left") is False
     assert mgr.handle_voice_command("hello") is False

--- a/xr/input_manager.py
+++ b/xr/input_manager.py
@@ -24,20 +24,20 @@ class InputManager:
 
         self._gestures[name] = callback
 
-    def unregister_gesture(self, name: str) -> None:
-        """Remove the gesture callback associated with ``name`` if present."""
+    def unregister_gesture(self, name: str) -> bool:
+        """Remove ``name`` and return ``True`` if a gesture callback existed."""
 
-        self._gestures.pop(name, None)
+        return self._gestures.pop(name, None) is not None
 
     def register_voice_command(self, phrase: str, callback: Callback) -> None:
         """Associate ``phrase`` with ``callback`` for voice events."""
 
         self._voice[phrase.lower()] = callback
 
-    def unregister_voice_command(self, phrase: str) -> None:
-        """Remove the voice callback associated with ``phrase`` if present."""
+    def unregister_voice_command(self, phrase: str) -> bool:
+        """Remove ``phrase`` and return ``True`` if a voice callback existed."""
 
-        self._voice.pop(phrase.lower(), None)
+        return self._voice.pop(phrase.lower(), None) is not None
 
     def handle_gesture(self, name: str) -> bool:
         """Invoke the callback mapped to ``name`` if present."""


### PR DESCRIPTION
## Summary
- return boolean status from InputManager.unregister_gesture and unregister_voice_command
- add tests validating callback registration and unregistration

## Testing
- `pytest tests/test_input_manager.py tests/test_xr_input_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68b513533bd88326aff5da9c328dd2c0