### PR TITLE
test: add overlap coverage

### DIFF
--- a/eco/scheduler.py
+++ b/eco/scheduler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, time, timedelta
 from threading import Timer
 from typing import Callable, Iterable, List, Optional, Tuple

--- a/tests/test_eco_scheduler.py
+++ b/tests/test_eco_scheduler.py
@@ -39,3 +39,13 @@ def test_cross_midnight_windows():
     now = datetime(2024, 1, 2, 2, 30)
     expected = datetime(2024, 1, 2, 3, 0)
     assert sched.next_run(now) == expected
+
+
+def test_cross_midnight_overlapping_windows():
+    sched = EcoScheduler(windows=[(23, 2), (0, 4)])
+    overlap = datetime(2024, 1, 1, 1, 30)
+    assert sched.is_off_peak(overlap)
+    assert sched.next_run(overlap) == overlap
+    now = datetime(2024, 1, 1, 22, 30)
+    expected = datetime(2024, 1, 1, 23, 0)
+    assert sched.next_run(now) == expected


### PR DESCRIPTION
## Summary
- remove unused dataclass import in `EcoScheduler`
- add tests verifying overlapping and cross-midnight off-peak windows

## Testing
- `pytest tests/test_eco_scheduler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b51355f9d08326b0766841da05b570