### PR TITLE
feat(iot): add zeroconf discovery adapter

### DIFF
--- a/iot/adapters/zeroconf.py
+++ b/iot/adapters/zeroconf.py
@@ -25,8 +25,20 @@ class ZeroconfAdapter(DeviceAdapter):
 
         class _Listener:
             def add_service(self, zeroconf, service_type, name):  # pragma: no cover - callback
+                info = zeroconf.get_service_info(service_type, name)
                 friendly = name.split(".")[0]
-                devices.append(Device(id=name, name=friendly, protocol=proto))
+                device_id = name
+                if info is not None:
+                    friendly = info.name.split(".")[0]
+                    props = getattr(info, "properties", {}) or {}
+                    dev_id = props.get(b"id")
+                    if isinstance(dev_id, bytes):
+                        device_id = dev_id.decode("utf-8", "ignore")
+                    elif dev_id is not None:
+                        device_id = str(dev_id)
+                    else:
+                        device_id = info.name
+                devices.append(Device(id=device_id, name=friendly, protocol=proto))
 
         zc = Zeroconf()
         try:

--- a/iot/models.py
+++ b/iot/models.py
@@ -24,4 +24,4 @@ class DeviceAdapter:
 
     def pair(self, device: Device) -> bool:
         """Pair with *device* and return True on success."""
-        return True
+        return device.protocol == self.protocol

--- a/tests/test_iot_discovery.py
+++ b/tests/test_iot_discovery.py
@@ -5,6 +5,7 @@ from iot import ADAPTERS, Device, discover_devices, pair_device
 
 def _mock_zeroconf(monkeypatch):
     import zeroconf
+    import iot.adapters.zeroconf as zc_adapter
 
     class FakeInfo:
         name = "ZCDevice._http._tcp.local."
@@ -22,6 +23,8 @@ def _mock_zeroconf(monkeypatch):
 
     monkeypatch.setattr(zeroconf, "Zeroconf", lambda: FakeZeroconf())
     monkeypatch.setattr(zeroconf, "ServiceBrowser", fake_service_browser)
+    monkeypatch.setattr(zc_adapter, "Zeroconf", lambda: FakeZeroconf())
+    monkeypatch.setattr(zc_adapter, "ServiceBrowser", fake_service_browser)
 
 
 def test_discover_devices_returns_devices(monkeypatch):

--- a/tests/test_zeroconf_adapter.py
+++ b/tests/test_zeroconf_adapter.py
@@ -6,18 +6,25 @@ from iot.adapters.zeroconf import ZeroconfAdapter
 def test_zeroconf_discover_simulated_devices():
     adapter = ZeroconfAdapter()
 
-    def fake_browser(zc, service_type, listener):
-        listener.add_service(zc, service_type, "TestDevice._http._tcp.local.")
-        return MagicMock()
+    fake_info = MagicMock()
+    fake_info.name = "TestDevice._http._tcp.local."
+    fake_info.properties = {b"id": b"device-1"}
 
     zc_instance = MagicMock()
+    zc_instance.get_service_info.return_value = fake_info
+
+    def fake_browser(zc, service_type, listener):
+        listener.add_service(zc, service_type, fake_info.name)
+        return MagicMock()
+
     with patch("iot.adapters.zeroconf.Zeroconf", return_value=zc_instance), \
          patch("iot.adapters.zeroconf.ServiceBrowser", side_effect=fake_browser):
         devices = adapter.discover()
 
     assert len(devices) == 1
     device = devices[0]
-    assert device.id == "TestDevice._http._tcp.local."
+    assert device.id == "device-1"
     assert device.name == "TestDevice"
     assert device.protocol == adapter.protocol
     zc_instance.close.assert_called_once()
+    zc_instance.get_service_info.assert_called_with("_http._tcp.local.", fake_info.name)


### PR DESCRIPTION
## Summary
- implement ZeroconfAdapter that resolves service info for discovered devices
- expose and test Zeroconf discovery, including integration with generic IoT discovery

## Testing
- `pytest tests/test_zeroconf_adapter.py -q`
- `pytest tests/test_iot_discovery.py -q`
- `pre-commit run --files iot/adapters/zeroconf.py tests/test_zeroconf_adapter.py tests/test_iot_discovery.py iot/models.py` *(fails: InvalidConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_68b51362525883269aa9b6daddc104c3