### PR TITLE
feat: return structured cleanup summaries

### DIFF
--- a/tests/test_explorer_ai.py
+++ b/tests/test_explorer_ai.py
@@ -13,6 +13,8 @@ class DummyModel:
                 action = "compress"
             else:
                 action = "keep"
+            # The dummy model only returns the action; the ExplorerAI combines
+            # this with metadata when producing the final summary.
             recommendations.append({"name": info["name"], "action": action})
         return json.dumps(recommendations)
 
@@ -29,8 +31,18 @@ def test_suggest_cleanup_records_prompt(tmp_path):
 
     result = explorer.suggest_cleanup([str(tmp_file), str(big_file)])
     assert result == [
-        {"name": str(tmp_file), "action": "delete"},
-        {"name": str(big_file), "action": "compress"},
+        {
+            "name": str(tmp_file),
+            "size": tmp_file.stat().st_size,
+            "extension": ".tmp",
+            "action": "delete",
+        },
+        {
+            "name": str(big_file),
+            "size": big_file.stat().st_size,
+            "extension": ".log",
+            "action": "compress",
+        },
     ]
 
     logs = explorer.get_logs()

--- a/windows_ai/explorer.py
+++ b/windows_ai/explorer.py
@@ -30,6 +30,8 @@ class ExplorerAI:
 
         file_info: List[Dict[str, Any]] = []
         for path in files:
+            # Collect metadata up front so it's available for prompting and
+            # for the structured summary returned to callers.
             size = os.path.getsize(path)
             ext = os.path.splitext(path)[1]
             file_info.append({"name": path, "size": size, "extension": ext})
@@ -39,9 +41,24 @@ class ExplorerAI:
 
         response = self.model.generate(prompt)
         try:
-            return json.loads(response)
+            model_data = json.loads(response)
         except json.JSONDecodeError:
-            return []
+            model_data = []
+
+        # Map the model's recommended action by file name for quick lookup.
+        actions = {item.get("name"): item.get("action") for item in model_data if isinstance(item, dict)}
+
+        summary: List[Dict[str, Any]] = []
+        for info in file_info:
+            summary.append(
+                {
+                    "name": info["name"],
+                    "size": info["size"],
+                    "extension": info["extension"],
+                    "action": actions.get(info["name"], "none"),
+                }
+            )
+        return summary
 
     def get_logs(self) -> List[str]:
         """Return recorded prompts."""


### PR DESCRIPTION
## Summary
- include file metadata in prompt and structured response
- recommend cleanup actions like delete or compress
- test ExplorerAI for metadata and recommendations

## Testing
- `pytest tests/test_explorer_ai.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5136475d8832693a296ee90765b1f