### PR TITLE
Add robust computer vision pipeline and tests

### DIFF
--- a/domains/computer_vision.py
+++ b/domains/computer_vision.py
@@ -20,25 +20,44 @@ from PIL import Image
 def input_processor(image: Any) -> Image.Image:
     """Prepare ``image`` data for model or API consumption.
 
-    The function ensures the input is a :class:`~PIL.Image.Image`, converts it
-    to RGB, and resizes it to ``224x224`` pixels.
+    Parameters
+    ----------
+    image:
+        Raw input which may be a :class:`~PIL.Image.Image`, a path to an
+        image on disk, a file like object or raw ``bytes``. The function
+        normalises the input into an RGB image with a fixed ``224x224`` size
+        which is a common default for vision models.
     """
 
     if isinstance(image, Image.Image):
         img = image
+    elif isinstance(image, (bytes, bytearray)):
+        # Accept raw bytes so callers can read from network or database
+        img = Image.open(io.BytesIO(image))
     else:  # Assume a file path or file-like object
         img = Image.open(image)
+
     img = img.convert("RGB")
     img = img.resize((224, 224))
     return img
 
 
-def task_planner(processed_image: Image.Image) -> Dict[str, Any]:
+def task_planner(processed_image: Image.Image, dark_threshold: int = 100) -> Dict[str, Any]:
     """Plan the sequence of vision tasks to perform.
 
-    A very small planner that always includes a local brightness analysis. If
-    the image is fairly dark (mean pixel value below ``100``), an additional
-    remote classification step is scheduled.
+    The planner currently performs a very small amount of reasoning.  A local
+    brightness calculation is always scheduled.  If the mean pixel value falls
+    below ``dark_threshold`` a secondary remote classification task is also
+    queued.
+
+    Parameters
+    ----------
+    processed_image:
+        Image that has already gone through :func:`input_processor`.
+    dark_threshold:
+        If the mean brightness is below this value a remote classification step
+        will be included.  Defaults to ``100`` which roughly indicates a dark
+        image.
     """
 
     gray = processed_image.convert("L")
@@ -48,13 +67,14 @@ def task_planner(processed_image: Image.Image) -> Dict[str, Any]:
         {"type": "local", "operation": "brightness", "image": gray}
     ]
 
-    if mean < 100:  # Arbitrary heuristic for demonstration purposes
+    if mean < dark_threshold:
         plan.append(
             {
                 "type": "remote",
                 "operation": "classify",
                 "url": "https://api.example.com/vision",
                 "image": processed_image,
+                "timeout": 10,
             }
         )
 
@@ -66,7 +86,9 @@ def executor(plan: Dict[str, Any]) -> Dict[str, Any]:
 
     Local tasks are performed directly with :mod:`PIL`. Remote tasks are sent to
     a hypothetical API endpoint using :func:`requests.post`. Each executed step
-    appends its output to the returned ``results`` list.
+    appends its output to the returned ``results`` list.  Network failures are
+    captured and returned as error entries so the caller can decide how to
+    handle them.
     """
 
     results: List[Dict[str, Any]] = []
@@ -81,9 +103,14 @@ def executor(plan: Dict[str, Any]) -> Dict[str, Any]:
             buffer = io.BytesIO()
             img.save(buffer, format="PNG")
             encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
-            response = requests.post(step["url"], json={"image": encoded})
-            response.raise_for_status()
-            results.append(response.json())
+            try:
+                response = requests.post(
+                    step["url"], json={"image": encoded}, timeout=step.get("timeout", 10)
+                )
+                response.raise_for_status()
+                results.append(response.json())
+            except requests.RequestException as exc:  # pragma: no cover - network error path
+                results.append({"error": str(exc)})
 
     return {"results": results}
 

--- a/tests/test_computer_vision.py
+++ b/tests/test_computer_vision.py
@@ -1,4 +1,7 @@
+import io
+
 import pytest
+import requests
 from PIL import Image
 
 from domains.computer_vision import (
@@ -16,6 +19,15 @@ def create_image(color: str, size=(50, 50)) -> Image.Image:
 def test_input_processor_resizes_and_converts():
     img = create_image("white", size=(10, 10))
     processed = input_processor(img)
+    assert processed.size == (224, 224)
+    assert processed.mode == "RGB"
+
+
+def test_input_processor_handles_bytes():
+    img = create_image("red", size=(10, 10))
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    processed = input_processor(buffer.getvalue())
     assert processed.size == (224, 224)
     assert processed.mode == "RGB"
 
@@ -46,9 +58,10 @@ def test_executor_runs_local_and_remote(monkeypatch):
         def raise_for_status(self):
             pass
 
-    def fake_post(url, json=None):
+    def fake_post(url, json=None, timeout=None):
         called["url"] = url
         called["payload"] = json
+        called["timeout"] = timeout
         return DummyResponse()
 
     monkeypatch.setattr("domains.computer_vision.requests.post", fake_post)
@@ -57,6 +70,20 @@ def test_executor_runs_local_and_remote(monkeypatch):
     assert results["results"][0]["brightness"] == 0.0
     assert results["results"][1] == {"classification": "test"}
     assert called["url"] == "https://api.example.com/vision"
+    assert called["timeout"] == 10
+
+
+def test_executor_returns_error_on_remote_failure(monkeypatch):
+    img = create_image("black", size=(224, 224))
+    plan = task_planner(img)
+
+    def fake_post(url, json=None, timeout=None):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr("domains.computer_vision.requests.post", fake_post)
+    results = executor(plan)
+
+    assert "error" in results["results"][1]
 
 
 def test_result_aggregator_combines_results():


### PR DESCRIPTION
## Summary
- support raw bytes input and error-aware remote execution in computer vision pipeline
- plan remote tasks based on brightness threshold with timeout
- test computer vision pipeline including byte handling, remote success and failure

## Testing
- `pytest tests/test_computer_vision.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5137599fc8326be1c6a5f5dd42c31