### PR TITLE
feat: bundle Python runtime in installer

### DIFF
--- a/build_installer.ps1
+++ b/build_installer.ps1
@@ -4,7 +4,8 @@
 param(
     [string]$PythonExe = "python",
     [string]$CertPath = "",
-    [string]$TimestampServer = ""
+    [string]$TimestampServer = "",
+    [string[]]$PythonOptions = @('--embed')
 )
 
 $ErrorActionPreference = 'Stop'
@@ -42,12 +43,21 @@ foreach ($arch in $architectures) {
     if (Test-Path $dist) { Remove-Item $dist -Recurse -Force }
     if (Test-Path $build) { Remove-Item $build -Recurse -Force }
 
-    & $PythonExe -m PyInstaller --noconfirm --onefile --windowed installer/gui_installer.py `
-        --name "WindowsAI_Installer_$arch" `
-        --distpath $dist `
-        --workpath $build `
-        --specpath $build `
-        --target-arch $arch
+    $pyArgs = @(
+        '--noconfirm','--onefile','--windowed','installer/gui_installer.py',
+        '--name',"WindowsAI_Installer_$arch",
+        '--distpath',$dist,
+        '--workpath',$build,
+        '--specpath',$build,
+        '--target-arch',$arch
+    )
+
+    foreach ($opt in $PythonOptions) {
+        $pyArgs += '--python-option'
+        $pyArgs += $opt
+    }
+
+    & $PythonExe -m PyInstaller @pyArgs
 
     foreach ($res in $resources) {
         if (Test-Path $res) {

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -11,6 +11,27 @@ Start-Transcript -Path $logPath -Force | Out-Null
 try {
     Write-Host "Installing Windows AI services..."
 
+    function Get-OrDownloadTool {
+        param(
+            [string]$CommandName,
+            [string]$Url,
+            [string]$DownloadName,
+            [string]$RelativePath = '',
+            [switch]$IsZip
+        )
+        $cmd = Get-Command $CommandName -ErrorAction SilentlyContinue
+        if ($cmd) { return $cmd.Path }
+        Write-Error "$CommandName not found; attempting download."
+        $dest = Join-Path $CacheDir $DownloadName
+        Invoke-WebRequest -Uri $Url -OutFile $dest -UseBasicParsing
+        if ($IsZip) {
+            Expand-Archive -Path $dest -DestinationPath $CacheDir -Force
+            if ($RelativePath) { return Join-Path $CacheDir $RelativePath }
+        } else {
+            return $dest
+        }
+    }
+
     # Start a new snapshot so we can rollback these actions later
     if (Get-Command python -ErrorAction SilentlyContinue) {
         python -m installer.snapshot create
@@ -18,35 +39,22 @@ try {
         Write-Error "python not found; snapshot creation skipped."
     }
 
-    $nssmCmd = Get-Command nssm.exe -ErrorAction SilentlyContinue
-    if (-not $nssmCmd) {
-        Write-Error "nssm.exe not found; attempting download."
-        $nssmZip = Join-Path $CacheDir 'nssm.zip'
-        $nssmUrl = 'https://nssm.cc/release/nssm-2.24.zip'
-        Invoke-WebRequest -Uri $nssmUrl -OutFile $nssmZip -UseBasicParsing
-        Expand-Archive -Path $nssmZip -DestinationPath $CacheDir -Force
-        $nssmPath = Join-Path $CacheDir 'nssm-2.24\win64\nssm.exe'
-    } else {
-        $nssmPath = $nssmCmd.Path
+    $nssmPath = Get-OrDownloadTool 'nssm.exe' 'https://nssm.cc/release/nssm-2.24.zip' 'nssm.zip' 'nssm-2.24\win64\nssm.exe' -IsZip
+    $mkcertPath = Get-OrDownloadTool 'mkcert.exe' 'https://dl.filippo.io/mkcert/latest?for=windows/amd64' 'mkcert.exe'
+    $nodePath = Get-OrDownloadTool 'node.exe' 'https://nodejs.org/dist/v20.12.1/node-v20.12.1-win-x64.zip' 'node.zip' 'node-v20.12.1-win-x64\node.exe' -IsZip
+
+    if (-not $nodePath) {
+        Write-Error "Unable to locate node executable; install aborted."
+        return
     }
 
     if (Test-Path $nssmPath) {
-        Start-Process -FilePath $nssmPath -ArgumentList 'install','WindowsAIService','node','apps\server.js' -Wait
+        Start-Process -FilePath $nssmPath -ArgumentList 'install','WindowsAIService',$nodePath,'apps\server.js' -Wait
         if (Get-Command python -ErrorAction SilentlyContinue) {
             python -m installer.snapshot record service WindowsAIService
         }
     } else {
         Write-Error "Unable to locate nssm executable; service installation skipped."
-    }
-
-    $mkcertCmd = Get-Command mkcert -ErrorAction SilentlyContinue
-    if (-not $mkcertCmd) {
-        Write-Error "mkcert not found; attempting download."
-        $mkcertPath = Join-Path $CacheDir 'mkcert.exe'
-        $mkcertUrl = 'https://dl.filippo.io/mkcert/latest?for=windows/amd64'
-        Invoke-WebRequest -Uri $mkcertUrl -OutFile $mkcertPath -UseBasicParsing
-    } else {
-        $mkcertPath = $mkcertCmd.Path
     }
 
     if (Test-Path $mkcertPath) {

--- a/tests/installer/test_full_install.py
+++ b/tests/installer/test_full_install.py
@@ -30,3 +30,5 @@ $env:TEMP='{tmp_path}'
     assert any("nssm.cc" in line for line in lines)
     assert any("mkcert" in line for line in lines)
     assert any("nodejs.org" in line for line in lines)
+    assert any(line.startswith("START:") and line.lower().endswith("nssm.exe") for line in lines)
+    assert any(line.startswith("START:") and line.lower().endswith("mkcert.exe") for line in lines)


### PR DESCRIPTION
## Summary
- bundle standalone Python runtime via PyInstaller `--python-option` for x86 and x64 builds
- auto-download missing nssm, mkcert, and Node.js during install
- add integration test that verifies prerequisite downloads

## Testing
- `pytest tests/installer/test_full_install.py -q` *(skipped: PowerShell not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b5137c03fc832698ecd9afb83288c1