### PR TITLE
fix: grant PR comment permissions

### DIFF
--- a/.github/workflows/pr-merge-conflict.yml
+++ b/.github/workflows/pr-merge-conflict.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
 jobs:
   merge-check:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant the merge conflict workflow write access to pull requests so comments can be posted

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f56d2915c08326863f46295cc45f66