### PR TITLE
Debug Windows installer build failures and module imports

### DIFF
--- a/build_installer.ps1
+++ b/build_installer.ps1
@@ -53,11 +53,21 @@ foreach ($arch in $architectures) {
     )
 
     foreach ($opt in $PythonOptions) {
-        $pyArgs += '--python-option'
-        $pyArgs += $opt
+        $pyArgs += "--python-option=$opt"
     }
 
     & $PythonExe -m PyInstaller @pyArgs
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "PyInstaller failed for $arch architecture with exit code $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
+
+    $installerPath = Join-Path $dist "WindowsAI_Installer_$arch.exe"
+    if (-not (Test-Path $installerPath)) {
+        Write-Error "PyInstaller did not produce expected output: $installerPath"
+        exit 1
+    }
 
     foreach ($res in $resources) {
         if (Test-Path $res) {
@@ -65,7 +75,7 @@ foreach ($arch in $architectures) {
         }
     }
 
-    Write-Output "Installer built at $dist\WindowsAI_Installer_$arch.exe"
+    Write-Output "Installer built successfully at $installerPath"
 }
 
 $installerExe = Join-Path $dist 'WindowsAI_Installer.exe'

--- a/installer/snapshot.py
+++ b/installer/snapshot.py
@@ -16,9 +16,6 @@ import logging
 import shutil
 from typing import Set
 
-from snapshot import capture as capture_config
-from snapshot import rollback as rollback_config
-
 # Location of the snapshot record
 CONFIG_DIR = Path.home() / ".windows_ai"
 SNAPSHOT_FILE = CONFIG_DIR / "snapshot.json"
@@ -142,22 +139,6 @@ def load_snapshot() -> Snapshot:
     return Snapshot.load()
 
 
-def snapshot_config(feature: str, path: Path | str) -> None:
-    """Capture configuration at ``path`` for ``feature``.
-
-    This delegates to :mod:`snapshot`'s :func:`capture` helper so that the
-    installer can restore individual features if a later step fails.
-    """
-
-    capture_config(feature, path)
-
-
-def rollback_feature(feature: str) -> None:
-    """Roll back configuration for ``feature`` using stored snapshots."""
-
-    rollback_config(feature)
-
-
 __all__ = [
     "Snapshot",
     "SNAPSHOT_FILE",
@@ -167,8 +148,6 @@ __all__ = [
     "record_firewall_rule",
     "restore",
     "load_snapshot",
-    "snapshot_config",
-    "rollback_feature",
 ]
 
 


### PR DESCRIPTION
- Remove unused snapshot module imports that were causing ImportError
- Fix PyInstaller --python-option syntax in build_installer.ps1
- Add proper error checking to build script to catch PyInstaller failures
- Remove unused snapshot_config and rollback_feature functions

These changes fix the following issues:
1. "cannot import name 'capture' from 'snapshot'" error
2. "pyinstaller: error: argument --python-option: expected one argument"
3. Build script printing success messages even when PyInstaller fails

## Summary

<!-- Summarize your changes -->

## Checklist
- [ ] Linked issue
- [ ] Tests added/updated
- [ ] Docs updated (README/docs)
- [ ] Changelog entry (CHANGELOG.md)
- [ ] Conventional commit message
- [ ] Followed [branching and rebasing guide](../CONTRIBUTING.md#pull-requests)
