### PR TITLE
Extend roadmap tracker through developer platform phase

### DIFF
--- a/tests/test_phase_tracker.py
+++ b/tests/test_phase_tracker.py
@@ -84,7 +84,7 @@ def test_phase_summary_contains_all_phases(phase_tracker: PhaseTracker):
     assert summary["phases"], "Expected at least one phase in the summary"
 
     phase_numbers = {phase["phase"] for phase in summary["phases"]}
-    assert {0, 1, 2, 3, 4}.issubset(phase_numbers)
+    assert set(range(0, 10)).issubset(phase_numbers)
 
 
 def test_phase_two_reports_automation_assets(phase_tracker: PhaseTracker):
@@ -105,3 +105,69 @@ def test_phase_tracker_serialization_models(phase_tracker: PhaseTracker):
     assert payload["completion"] >= 0
     assert isinstance(payload["goals"], list)
     assert all("id" in goal and "completed" in goal for goal in payload["goals"])
+
+
+def test_phase_five_ecosystem_metrics(phase_tracker: PhaseTracker):
+    phase_five = phase_tracker.get_phase_status_by_id(5)
+    assert phase_five is not None
+
+    metadata = phase_five.metadata
+
+    assert metadata["plugins"]["count"] >= 5
+    assert metadata["plugins"]["registry_ready"]
+    assert metadata["plugins"]["loader_ready"]
+
+    assert metadata["ecosystem"]["marketplace"]
+    assert metadata["ecosystem"]["marketplace_entry"]
+    assert metadata["ecosystem"]["model_discovery"]
+    assert metadata["ecosystem"]["discovery_modules"] >= 1
+
+    assert metadata["community"]["community_ready"]
+    assert metadata["community"]["docs"].get("CONTRIBUTING.md")
+
+
+def test_phase_six_capsules_and_policies(phase_tracker: PhaseTracker):
+    phase_six = phase_tracker.get_phase_status_by_id(6)
+    assert phase_six is not None
+
+    metadata = phase_six.metadata
+    assert metadata["capsules"]["workflow_templates"] >= 3
+    assert metadata["capsules"]["marketplace_ready"]
+    assert metadata["policies"]["documents"] >= 3
+    assert metadata["policies"]["engine_ready"]
+
+
+def test_phase_seven_operations_and_updates(phase_tracker: PhaseTracker):
+    phase_seven = phase_tracker.get_phase_status_by_id(7)
+    assert phase_seven is not None
+
+    metadata = phase_seven.metadata
+    assert metadata["operations"]["watchdog"]["script_ready"]
+    assert metadata["operations"]["watchdog"]["docs_ready"]
+    assert metadata["updates"]["server_ready"]
+    assert metadata["deployment"]["scripts"] >= 6
+    assert metadata["operations"]["rollback_ready"]
+
+
+def test_phase_eight_companion_experiences(phase_tracker: PhaseTracker):
+    phase_eight = phase_tracker.get_phase_status_by_id(8)
+    assert phase_eight is not None
+
+    metadata = phase_eight.metadata
+    assert metadata["experiences"]["mobile_ready"]
+    assert metadata["experiences"]["first_run_ready"]
+    assert metadata["experiences"]["desktop_wizard_ready"]
+    assert metadata["apps"]["portfolio_ready"]
+    assert metadata["docs"]["complete"]
+
+
+def test_phase_nine_developer_platform(phase_tracker: PhaseTracker):
+    phase_nine = phase_tracker.get_phase_status_by_id(9)
+    assert phase_nine is not None
+
+    metadata = phase_nine.metadata
+    assert metadata["sdk"]["language_count"] >= 3
+    assert metadata["api"]["exists"]
+    assert metadata["distribution"]["agent_ready"]
+    assert metadata["docs"]["complete"]
+    assert metadata["domains"]["samples_ready"]

--- a/windows_ai/phase_tracker.py
+++ b/windows_ai/phase_tracker.py
@@ -93,6 +93,11 @@ class PhaseTracker:
             self._phase_2_status(plugin_count, watchers, tasks),
             self._phase_3_status(),
             self._phase_4_status(),
+            self._phase_5_status(plugin_count),
+            self._phase_6_status(),
+            self._phase_7_status(),
+            self._phase_8_status(),
+            self._phase_9_status(),
         ]
         return statuses
 
@@ -274,6 +279,480 @@ class PhaseTracker:
             phase=4,
             name="Phase 4 — Packaging & Delivery",
             description="Installers, release automation, and validation suites",
+            goals=goals,
+            metadata=metadata,
+        )
+
+    def _phase_5_status(self, plugin_count: int) -> PhaseStatus:
+        plugins_root = self.repo_root / "windows_ai" / "plugins"
+        registry_ready = (plugins_root / "registry.py").exists()
+        loader_ready = (plugins_root / "loader.py").exists()
+
+        marketplace_root = self.repo_root / "marketplace"
+        marketplace_ready = marketplace_root.exists()
+        marketplace_entry = (marketplace_root / "main.py").exists()
+
+        model_discovery_root = self.repo_root / "model_discovery"
+        model_discovery_ready = model_discovery_root.exists()
+        discovery_modules = 0
+        if model_discovery_ready:
+            discovery_modules = sum(
+                1
+                for path in model_discovery_root.glob("*.py")
+                if path.is_file()
+            )
+
+        community_docs = [
+            self.repo_root / "CONTRIBUTING.md",
+            self.repo_root / "CHANGELOG.md",
+            self.docs_root / "ROADMAP.md",
+            self.docs_root / "ROADMAP_IMPLEMENTATION.md",
+        ]
+        community_status: Dict[str, bool] = {}
+        for doc_path in community_docs:
+            try:
+                key = str(doc_path.relative_to(self.repo_root))
+            except ValueError:  # pragma: no cover - defensive safety
+                key = str(doc_path)
+            community_status[key] = doc_path.exists()
+
+        community_ready = all(community_status.values())
+
+        plugin_catalog_ready = plugin_count >= 5
+
+        goals = [
+            PhaseGoal(
+                "plugin-catalog",
+                "Plugin catalog populated",
+                plugin_catalog_ready,
+                f"{plugin_count} plugins discovered",
+            ),
+            PhaseGoal(
+                "plugin-registry",
+                "Plugin registry operational",
+                registry_ready and loader_ready,
+                "windows_ai/plugins/",
+            ),
+            PhaseGoal(
+                "model-discovery",
+                "Model discovery service available",
+                model_discovery_ready and discovery_modules >= 2,
+                f"{discovery_modules} discovery modules",
+            ),
+            PhaseGoal(
+                "marketplace",
+                "Marketplace tooling ready",
+                marketplace_ready and marketplace_entry,
+                "marketplace/main.py",
+            ),
+            PhaseGoal(
+                "community",
+                "Community guides published",
+                community_ready,
+                ", ".join(sorted(community_status.keys())),
+            ),
+        ]
+
+        metadata = {
+            "plugins": {
+                "count": plugin_count,
+                "registry_ready": registry_ready,
+                "loader_ready": loader_ready,
+                "catalog_path": str(self.plugin_dir),
+            },
+            "ecosystem": {
+                "marketplace": marketplace_ready,
+                "marketplace_entry": marketplace_entry,
+                "model_discovery": model_discovery_ready,
+                "discovery_modules": discovery_modules,
+            },
+            "community": {
+                "docs": community_status,
+                "community_ready": community_ready,
+            },
+        }
+
+        return PhaseStatus(
+            phase=5,
+            name="Phase 5 — Ecosystem & Growth",
+            description="Plugin marketplace, model discovery, and community enablement",
+            goals=goals,
+            metadata=metadata,
+        )
+
+    def _phase_6_status(self) -> PhaseStatus:
+        control_center_dir = self.repo_root / "control_center"
+        ui_modules = 0
+        if control_center_dir.exists():
+            ui_modules = sum(1 for path in control_center_dir.glob("*.py") if path.is_file())
+
+        workflow_dir = self.repo_root / "assets" / "workflows"
+        workflow_templates = 0
+        if workflow_dir.exists():
+            workflow_templates = sum(1 for path in workflow_dir.rglob("*.yaml"))
+
+        marketplace_root = self.repo_root / "marketplace"
+        marketplace_entry = marketplace_root / "main.py"
+        marketplace_ready = marketplace_root.exists() and marketplace_entry.exists()
+
+        policy_docs = [
+            self.repo_root / "SECURITY.md",
+            self.docs_root / "security.md",
+            self.docs_root / "security_privacy.md",
+            self.docs_root / "SECURITY_ENCRYPTION.md",
+        ]
+        policy_document_status: Dict[str, bool] = {}
+        for doc in policy_docs:
+            try:
+                key = str(doc.relative_to(self.repo_root))
+            except ValueError:  # pragma: no cover - defensive safety
+                key = str(doc)
+            policy_document_status[key] = doc.exists()
+        policy_document_count = sum(1 for present in policy_document_status.values() if present)
+
+        permissions_module = self.repo_root / "security" / "permissions.py"
+        audit_module = self.repo_root / "security" / "audit.py"
+        policy_engine_ready = permissions_module.exists() and audit_module.exists()
+
+        workflow_threshold_met = workflow_templates >= 3
+        ui_threshold_met = ui_modules >= 5
+        catalog_ready = workflow_threshold_met and ui_threshold_met and marketplace_ready
+
+        goals = [
+            PhaseGoal(
+                "capsule-ui",
+                "Control Center capsules and marketplace surfaces",
+                ui_threshold_met,
+                f"{ui_modules} UI modules in control_center/",
+            ),
+            PhaseGoal(
+                "capsule-templates",
+                "Workflow capsules curated",
+                workflow_threshold_met,
+                f"{workflow_templates} workflow templates",
+            ),
+            PhaseGoal(
+                "marketplace-surface",
+                "Marketplace entry + UI stitched",
+                marketplace_ready,
+                str(marketplace_entry),
+            ),
+            PhaseGoal(
+                "policy-docs",
+                "Security and governance policies published",
+                policy_document_count >= 3,
+                ", ".join(sorted(policy_document_status.keys())),
+            ),
+            PhaseGoal(
+                "policy-engine",
+                "Policy enforcement engine wired up",
+                policy_engine_ready,
+                "security/permissions.py, security/audit.py",
+            ),
+        ]
+
+        metadata = {
+            "capsules": {
+                "ui_modules": ui_modules,
+                "workflow_templates": workflow_templates,
+                "marketplace_ready": marketplace_ready,
+                "catalog_ready": catalog_ready,
+            },
+            "policies": {
+                "documents": policy_document_count,
+                "document_status": policy_document_status,
+                "engine_ready": policy_engine_ready,
+                "permissions_module": str(permissions_module),
+                "audit_module": str(audit_module),
+            },
+        }
+
+        return PhaseStatus(
+            phase=6,
+            name="Phase 6 — Capsules & Policy Governance",
+            description="Capsule storefront, curated templates, and policy guardrails",
+            goals=goals,
+            metadata=metadata,
+        )
+
+    def _phase_7_status(self) -> PhaseStatus:
+        watchdog_script = self.repo_root / "watchdog.py"
+        watchdog_docs = self.docs_root / "WATCHDOG.md"
+        watchdog_docs_ready = watchdog_docs.exists()
+        watchdog_ready = watchdog_script.exists()
+
+        update_server = self.repo_root / "update-server" / "server.py"
+        update_manifest = self.repo_root / "update-server" / "manifest.json"
+        update_server_ready = update_server.exists() and update_manifest.exists()
+
+        deployment_scripts = [
+            path
+            for path in self.repo_root.glob("start-*.*")
+            if path.suffix.lower() in {".sh", ".bat", ".ps1"}
+        ]
+        deployment_script_count = len(deployment_scripts)
+        deployment_scripts_ready = deployment_script_count >= 6
+
+        updates_docs = [
+            self.docs_root / "updates.md",
+            self.docs_root / "Smart-Installer.md",
+            self.docs_root / "uninstall.md",
+        ]
+        updates_documentation_ready = all(doc.exists() for doc in updates_docs)
+
+        rollback_module = self.repo_root / "security" / "rollback.py"
+        rollback_docs = self.docs_root / "rollback.md"
+        rollback_ready = rollback_module.exists() and rollback_docs.exists()
+
+        goals = [
+            PhaseGoal(
+                "watchdog",
+                "Watchdog self-healing service",
+                watchdog_ready and watchdog_docs_ready,
+                f"watchdog.py + {watchdog_docs.name}",
+            ),
+            PhaseGoal(
+                "update-server",
+                "Update server deployment assets",
+                update_server_ready,
+                "update-server/server.py",
+            ),
+            PhaseGoal(
+                "deploy-scripts",
+                "Cross-platform deployment scripts",
+                deployment_scripts_ready,
+                f"{deployment_script_count} start-* scripts",
+            ),
+            PhaseGoal(
+                "update-docs",
+                "Update + uninstall runbooks",
+                updates_documentation_ready,
+                ", ".join(doc.name for doc in updates_docs),
+            ),
+            PhaseGoal(
+                "rollback-automation",
+                "Rollback + recovery automation",
+                rollback_ready,
+                f"{rollback_module} + {rollback_docs}",
+            ),
+        ]
+
+        metadata = {
+            "operations": {
+                "watchdog": {
+                    "script_ready": watchdog_ready,
+                    "docs_ready": watchdog_docs_ready,
+                },
+                "rollback_ready": rollback_ready,
+            },
+            "updates": {
+                "server_ready": update_server_ready,
+                "manifest": str(update_manifest),
+                "documentation_ready": updates_documentation_ready,
+            },
+            "deployment": {
+                "scripts": deployment_script_count,
+                "scripts_ready": deployment_scripts_ready,
+            },
+        }
+
+        return PhaseStatus(
+            phase=7,
+            name="Phase 7 — Operations & Extreme Hardening",
+            description="Watchdog, updates, and recovery automation for production scale",
+            goals=goals,
+            metadata=metadata,
+        )
+
+    def _phase_8_status(self) -> PhaseStatus:
+        mobile_app = self.repo_root / "mobile" / "package.json"
+        first_run_wizard = self.repo_root / "first-run-wizard" / "wizard.html"
+        desktop_wizard = self.repo_root / "wizard" / "wizard.html"
+
+        apps_root = self.repo_root / "apps"
+        app_projects = []
+        if apps_root.exists():
+            for package_file in apps_root.glob("*/package.json"):
+                if package_file.is_file():
+                    app_projects.append(package_file.parent.name)
+        app_project_count = len(app_projects)
+        portfolio_ready = app_project_count >= 3
+
+        experience_docs = [
+            self.docs_root / "AI-Control-Center.md",
+            self.docs_root / "AUTOMATION_UI.md",
+            self.docs_root / "ACTIONS_API.md",
+        ]
+        doc_status: Dict[str, bool] = {}
+        for doc in experience_docs:
+            try:
+                key = str(doc.relative_to(self.repo_root))
+            except ValueError:  # pragma: no cover - defensive safety
+                key = str(doc)
+            doc_status[key] = doc.exists()
+        docs_ready = all(doc_status.values()) and len(doc_status) >= 3
+
+        goals = [
+            PhaseGoal(
+                "mobile-companion",
+                "Mobile companion experience",
+                mobile_app.exists(),
+                str(mobile_app),
+            ),
+            PhaseGoal(
+                "first-run-wizard",
+                "First-run wizard onboarding",
+                first_run_wizard.exists(),
+                str(first_run_wizard),
+            ),
+            PhaseGoal(
+                "desktop-onboarding",
+                "Desktop setup wizard",
+                desktop_wizard.exists(),
+                str(desktop_wizard),
+            ),
+            PhaseGoal(
+                "app-portfolio",
+                "Desktop and service app portfolio",
+                portfolio_ready,
+                f"{app_project_count} Electron/Node app projects",
+            ),
+            PhaseGoal(
+                "experience-docs",
+                "Cross-surface documentation",
+                docs_ready,
+                ", ".join(sorted(doc_status.keys())),
+            ),
+        ]
+
+        metadata = {
+            "experiences": {
+                "mobile_ready": mobile_app.exists(),
+                "first_run_ready": first_run_wizard.exists(),
+                "desktop_wizard_ready": desktop_wizard.exists(),
+            },
+            "apps": {
+                "projects": app_projects,
+                "portfolio_ready": portfolio_ready,
+            },
+            "docs": {
+                "coverage": doc_status,
+                "complete": docs_ready,
+            },
+        }
+
+        return PhaseStatus(
+            phase=8,
+            name="Phase 8 — Companion Surfaces & Onboarding",
+            description="Mobile, desktop wizards, and multi-app experiences",
+            goals=goals,
+            metadata=metadata,
+        )
+
+    def _phase_9_status(self) -> PhaseStatus:
+        sdk_root = self.repo_root / "sdk"
+        sdk_languages: Dict[str, bool] = {}
+        if sdk_root.exists():
+            for child in sdk_root.iterdir():
+                if not child.is_dir():
+                    continue
+                has_assets = any(child.glob("*.py")) or any(child.glob("*.js")) or any(
+                    child.glob("*.ts")
+                )
+                sdk_languages[child.name] = has_assets
+        sdk_language_count = sum(1 for ready in sdk_languages.values() if ready)
+
+        openapi_spec = self.repo_root / "openapi" / "windows-ai.yaml"
+
+        agent_dir = self.repo_root / "windows-ai-agent"
+        agent_package = agent_dir / "package.json"
+        agent_bin = agent_dir / "bin"
+        agent_ready = agent_package.exists() and agent_bin.exists()
+
+        developer_docs = [
+            self.docs_root / "API_REFERENCE.md",
+            self.docs_root / "ACTIONS_API.md",
+            self.docs_root / "ENHANCEMENTS_SUMMARY.md",
+        ]
+        developer_doc_status: Dict[str, bool] = {}
+        for doc in developer_docs:
+            try:
+                key = str(doc.relative_to(self.repo_root))
+            except ValueError:  # pragma: no cover - defensive safety
+                key = str(doc)
+            developer_doc_status[key] = doc.exists()
+        developer_doc_ready = all(developer_doc_status.values())
+
+        domains_root = self.repo_root / "domains"
+        domain_samples = []
+        if domains_root.exists():
+            for module in domains_root.glob("*.py"):
+                if module.name == "__init__.py" or not module.is_file():
+                    continue
+                domain_samples.append(module.name)
+        domain_samples_ready = len(domain_samples) >= 3
+
+        goals = [
+            PhaseGoal(
+                "sdk-languages",
+                "Multi-language SDK coverage",
+                sdk_language_count >= 3,
+                f"{sdk_language_count} SDK languages",
+            ),
+            PhaseGoal(
+                "openapi-spec",
+                "OpenAPI contract published",
+                openapi_spec.exists(),
+                str(openapi_spec),
+            ),
+            PhaseGoal(
+                "cli-agent",
+                "Agent CLI distribution",
+                agent_ready,
+                str(agent_dir),
+            ),
+            PhaseGoal(
+                "developer-docs",
+                "Developer reference documentation",
+                developer_doc_ready,
+                ", ".join(sorted(developer_doc_status.keys())),
+            ),
+            PhaseGoal(
+                "domain-samples",
+                "Reference domain samples",
+                domain_samples_ready,
+                ", ".join(sorted(domain_samples)),
+            ),
+        ]
+
+        metadata = {
+            "sdk": {
+                "languages": sdk_languages,
+                "language_count": sdk_language_count,
+            },
+            "api": {
+                "openapi_spec": str(openapi_spec),
+                "exists": openapi_spec.exists(),
+            },
+            "distribution": {
+                "agent_ready": agent_ready,
+                "package_json": str(agent_package),
+                "bin_path": str(agent_bin),
+            },
+            "docs": {
+                "coverage": developer_doc_status,
+                "complete": developer_doc_ready,
+            },
+            "domains": {
+                "samples": domain_samples,
+                "samples_ready": domain_samples_ready,
+            },
+        }
+
+        return PhaseStatus(
+            phase=9,
+            name="Phase 9 — Developer Platform & Distribution",
+            description="SDK coverage, contracts, and CLI packaging",
             goals=goals,
             metadata=metadata,
         )


### PR DESCRIPTION
## Summary
- extend the roadmap tracker with new Phase 8 and Phase 9 computations covering mobile companions, onboarding flows, SDKs, and developer distribution assets
- capture cross-surface documentation, app portfolio metrics, OpenAPI contracts, SDK language coverage, CLI packaging, and domain sample readiness in the new phase metadata
- update the unit tests to require the new phases in the summary and to validate the additional metadata requirements

## Testing
- pytest tests/test_phase_tracker.py -q -o addopts=


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150b0618a883268c4b95098281b8c8)