### PR TITLE
Expand roadmap upgrades across all phases

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -125,6 +125,106 @@ This phase focuses on establishing a robust and scalable foundation, integrating
 *   **Upgrade 098:** Publish `docs/security/threat-model-foundation.md` capturing threats relevant to the base architecture.
 *   **Upgrade 099:** Add `scripts/dev/track-experimental-features.py` to register experimental toggles and owners.
 *   **Upgrade 100:** Create `docs/architecture/foundation-maturity-model.md` to benchmark progress across foundational milestones.
+*   **Upgrade 501:** Add `scripts/dev/environment_audit.py` delivering recurring audits for environment provisioning across services.
+*   **Upgrade 502:** Introduce `scripts/dev/environment_dashboard.py` providing live dashboards that surface environment provisioning status in real time.
+*   **Upgrade 503:** Implement `scripts/dev/environment_playbook.py` capturing step-by-step playbooks to reinforce environment provisioning.
+*   **Upgrade 504:** Create `scripts/dev/environment_scorecard.py` summarizing environment provisioning progress against roadmap targets.
+*   **Upgrade 505:** Publish `scripts/dev/environment_matrix.py` mapping environment provisioning coverage across foundational modules.
+*   **Upgrade 506:** Provide `scripts/dev/environment_handbook.py` offering a handbook so contributors internalize environment provisioning.
+*   **Upgrade 507:** Ship `scripts/dev/environment_inspector.py` automating inspections that verify environment provisioning before merges.
+*   **Upgrade 508:** Build `scripts/dev/environment_notebook.py` curating exploratory notebooks that showcase environment provisioning best practices.
+*   **Upgrade 509:** Document `scripts/dev/environment_registry.py` maintaining a registry of owners responsible for environment provisioning.
+*   **Upgrade 510:** Establish `scripts/dev/environment_roadmap.py` aligning the foundational roadmap milestones with environment provisioning.
+*   **Upgrade 511:** Add `scripts/ci/dependency_audit.py` delivering recurring audits for dependency health across services.
+*   **Upgrade 512:** Introduce `scripts/ci/dependency_dashboard.py` providing live dashboards that surface dependency health status in real time.
+*   **Upgrade 513:** Implement `scripts/ci/dependency_playbook.py` capturing step-by-step playbooks to reinforce dependency health.
+*   **Upgrade 514:** Create `scripts/ci/dependency_scorecard.py` summarizing dependency health progress against roadmap targets.
+*   **Upgrade 515:** Publish `scripts/ci/dependency_matrix.py` mapping dependency health coverage across foundational modules.
+*   **Upgrade 516:** Provide `scripts/ci/dependency_handbook.py` offering a handbook so contributors internalize dependency health.
+*   **Upgrade 517:** Ship `scripts/ci/dependency_inspector.py` automating inspections that verify dependency health before merges.
+*   **Upgrade 518:** Build `scripts/ci/dependency_notebook.py` curating exploratory notebooks that showcase dependency health best practices.
+*   **Upgrade 519:** Document `scripts/ci/dependency_registry.py` maintaining a registry of owners responsible for dependency health.
+*   **Upgrade 520:** Establish `scripts/ci/dependency_roadmap.py` aligning the foundational roadmap milestones with dependency health.
+*   **Upgrade 521:** Add `docs/architecture/architecture_audit.md` delivering recurring audits for architecture governance across services.
+*   **Upgrade 522:** Introduce `docs/architecture/architecture_dashboard.md` providing live dashboards that surface architecture governance status in real time.
+*   **Upgrade 523:** Implement `docs/architecture/architecture_playbook.md` capturing step-by-step playbooks to reinforce architecture governance.
+*   **Upgrade 524:** Create `docs/architecture/architecture_scorecard.md` summarizing architecture governance progress against roadmap targets.
+*   **Upgrade 525:** Publish `docs/architecture/architecture_matrix.md` mapping architecture governance coverage across foundational modules.
+*   **Upgrade 526:** Provide `docs/architecture/architecture_handbook.md` offering a handbook so contributors internalize architecture governance.
+*   **Upgrade 527:** Ship `docs/architecture/architecture_inspector.md` automating inspections that verify architecture governance before merges.
+*   **Upgrade 528:** Build `docs/architecture/architecture_notebook.md` curating exploratory notebooks that showcase architecture governance best practices.
+*   **Upgrade 529:** Document `docs/architecture/architecture_registry.md` maintaining a registry of owners responsible for architecture governance.
+*   **Upgrade 530:** Establish `docs/architecture/architecture_roadmap.md` aligning the foundational roadmap milestones with architecture governance.
+*   **Upgrade 531:** Add `docs/operations/operations_audit.md` delivering recurring audits for operations readiness across services.
+*   **Upgrade 532:** Introduce `docs/operations/operations_dashboard.md` providing live dashboards that surface operations readiness status in real time.
+*   **Upgrade 533:** Implement `docs/operations/operations_playbook.md` capturing step-by-step playbooks to reinforce operations readiness.
+*   **Upgrade 534:** Create `docs/operations/operations_scorecard.md` summarizing operations readiness progress against roadmap targets.
+*   **Upgrade 535:** Publish `docs/operations/operations_matrix.md` mapping operations readiness coverage across foundational modules.
+*   **Upgrade 536:** Provide `docs/operations/operations_handbook.md` offering a handbook so contributors internalize operations readiness.
+*   **Upgrade 537:** Ship `docs/operations/operations_inspector.md` automating inspections that verify operations readiness before merges.
+*   **Upgrade 538:** Build `docs/operations/operations_notebook.md` curating exploratory notebooks that showcase operations readiness best practices.
+*   **Upgrade 539:** Document `docs/operations/operations_registry.md` maintaining a registry of owners responsible for operations readiness.
+*   **Upgrade 540:** Establish `docs/operations/operations_roadmap.md` aligning the foundational roadmap milestones with operations readiness.
+*   **Upgrade 541:** Add `docs/security/security_audit.md` delivering recurring audits for foundational security posture across services.
+*   **Upgrade 542:** Introduce `docs/security/security_dashboard.md` providing live dashboards that surface foundational security posture status in real time.
+*   **Upgrade 543:** Implement `docs/security/security_playbook.md` capturing step-by-step playbooks to reinforce foundational security posture.
+*   **Upgrade 544:** Create `docs/security/security_scorecard.md` summarizing foundational security posture progress against roadmap targets.
+*   **Upgrade 545:** Publish `docs/security/security_matrix.md` mapping foundational security posture coverage across foundational modules.
+*   **Upgrade 546:** Provide `docs/security/security_handbook.md` offering a handbook so contributors internalize foundational security posture.
+*   **Upgrade 547:** Ship `docs/security/security_inspector.md` automating inspections that verify foundational security posture before merges.
+*   **Upgrade 548:** Build `docs/security/security_notebook.md` curating exploratory notebooks that showcase foundational security posture best practices.
+*   **Upgrade 549:** Document `docs/security/security_registry.md` maintaining a registry of owners responsible for foundational security posture.
+*   **Upgrade 550:** Establish `docs/security/security_roadmap.md` aligning the foundational roadmap milestones with foundational security posture.
+*   **Upgrade 551:** Add `docs/testing/testing_audit.md` delivering recurring audits for baseline testing discipline across services.
+*   **Upgrade 552:** Introduce `docs/testing/testing_dashboard.md` providing live dashboards that surface baseline testing discipline status in real time.
+*   **Upgrade 553:** Implement `docs/testing/testing_playbook.md` capturing step-by-step playbooks to reinforce baseline testing discipline.
+*   **Upgrade 554:** Create `docs/testing/testing_scorecard.md` summarizing baseline testing discipline progress against roadmap targets.
+*   **Upgrade 555:** Publish `docs/testing/testing_matrix.md` mapping baseline testing discipline coverage across foundational modules.
+*   **Upgrade 556:** Provide `docs/testing/testing_handbook.md` offering a handbook so contributors internalize baseline testing discipline.
+*   **Upgrade 557:** Ship `docs/testing/testing_inspector.md` automating inspections that verify baseline testing discipline before merges.
+*   **Upgrade 558:** Build `docs/testing/testing_notebook.md` curating exploratory notebooks that showcase baseline testing discipline best practices.
+*   **Upgrade 559:** Document `docs/testing/testing_registry.md` maintaining a registry of owners responsible for baseline testing discipline.
+*   **Upgrade 560:** Establish `docs/testing/testing_roadmap.md` aligning the foundational roadmap milestones with baseline testing discipline.
+*   **Upgrade 561:** Add `tools/foundation/tooling_audit.json` delivering recurring audits for shared tooling catalogs across services.
+*   **Upgrade 562:** Introduce `tools/foundation/tooling_dashboard.json` providing live dashboards that surface shared tooling catalogs status in real time.
+*   **Upgrade 563:** Implement `tools/foundation/tooling_playbook.json` capturing step-by-step playbooks to reinforce shared tooling catalogs.
+*   **Upgrade 564:** Create `tools/foundation/tooling_scorecard.json` summarizing shared tooling catalogs progress against roadmap targets.
+*   **Upgrade 565:** Publish `tools/foundation/tooling_matrix.json` mapping shared tooling catalogs coverage across foundational modules.
+*   **Upgrade 566:** Provide `tools/foundation/tooling_handbook.json` offering a handbook so contributors internalize shared tooling catalogs.
+*   **Upgrade 567:** Ship `tools/foundation/tooling_inspector.json` automating inspections that verify shared tooling catalogs before merges.
+*   **Upgrade 568:** Build `tools/foundation/tooling_notebook.json` curating exploratory notebooks that showcase shared tooling catalogs best practices.
+*   **Upgrade 569:** Document `tools/foundation/tooling_registry.json` maintaining a registry of owners responsible for shared tooling catalogs.
+*   **Upgrade 570:** Establish `tools/foundation/tooling_roadmap.json` aligning the foundational roadmap milestones with shared tooling catalogs.
+*   **Upgrade 571:** Add `assets/workflows/workflows_audit.yaml` delivering recurring audits for bootstrap workflow templates across services.
+*   **Upgrade 572:** Introduce `assets/workflows/workflows_dashboard.yaml` providing live dashboards that surface bootstrap workflow templates status in real time.
+*   **Upgrade 573:** Implement `assets/workflows/workflows_playbook.yaml` capturing step-by-step playbooks to reinforce bootstrap workflow templates.
+*   **Upgrade 574:** Create `assets/workflows/workflows_scorecard.yaml` summarizing bootstrap workflow templates progress against roadmap targets.
+*   **Upgrade 575:** Publish `assets/workflows/workflows_matrix.yaml` mapping bootstrap workflow templates coverage across foundational modules.
+*   **Upgrade 576:** Provide `assets/workflows/workflows_handbook.yaml` offering a handbook so contributors internalize bootstrap workflow templates.
+*   **Upgrade 577:** Ship `assets/workflows/workflows_inspector.yaml` automating inspections that verify bootstrap workflow templates before merges.
+*   **Upgrade 578:** Build `assets/workflows/workflows_notebook.yaml` curating exploratory notebooks that showcase bootstrap workflow templates best practices.
+*   **Upgrade 579:** Document `assets/workflows/workflows_registry.yaml` maintaining a registry of owners responsible for bootstrap workflow templates.
+*   **Upgrade 580:** Establish `assets/workflows/workflows_roadmap.yaml` aligning the foundational roadmap milestones with bootstrap workflow templates.
+*   **Upgrade 581:** Add `docs/standards/communication_audit.md` delivering recurring audits for team communication rituals across services.
+*   **Upgrade 582:** Introduce `docs/standards/communication_dashboard.md` providing live dashboards that surface team communication rituals status in real time.
+*   **Upgrade 583:** Implement `docs/standards/communication_playbook.md` capturing step-by-step playbooks to reinforce team communication rituals.
+*   **Upgrade 584:** Create `docs/standards/communication_scorecard.md` summarizing team communication rituals progress against roadmap targets.
+*   **Upgrade 585:** Publish `docs/standards/communication_matrix.md` mapping team communication rituals coverage across foundational modules.
+*   **Upgrade 586:** Provide `docs/standards/communication_handbook.md` offering a handbook so contributors internalize team communication rituals.
+*   **Upgrade 587:** Ship `docs/standards/communication_inspector.md` automating inspections that verify team communication rituals before merges.
+*   **Upgrade 588:** Build `docs/standards/communication_notebook.md` curating exploratory notebooks that showcase team communication rituals best practices.
+*   **Upgrade 589:** Document `docs/standards/communication_registry.md` maintaining a registry of owners responsible for team communication rituals.
+*   **Upgrade 590:** Establish `docs/standards/communication_roadmap.md` aligning the foundational roadmap milestones with team communication rituals.
+*   **Upgrade 591:** Add `docs/observability/observability_audit.md` delivering recurring audits for foundational observability across services.
+*   **Upgrade 592:** Introduce `docs/observability/observability_dashboard.md` providing live dashboards that surface foundational observability status in real time.
+*   **Upgrade 593:** Implement `docs/observability/observability_playbook.md` capturing step-by-step playbooks to reinforce foundational observability.
+*   **Upgrade 594:** Create `docs/observability/observability_scorecard.md` summarizing foundational observability progress against roadmap targets.
+*   **Upgrade 595:** Publish `docs/observability/observability_matrix.md` mapping foundational observability coverage across foundational modules.
+*   **Upgrade 596:** Provide `docs/observability/observability_handbook.md` offering a handbook so contributors internalize foundational observability.
+*   **Upgrade 597:** Ship `docs/observability/observability_inspector.md` automating inspections that verify foundational observability before merges.
+*   **Upgrade 598:** Build `docs/observability/observability_notebook.md` curating exploratory notebooks that showcase foundational observability best practices.
+*   **Upgrade 599:** Document `docs/observability/observability_registry.md` maintaining a registry of owners responsible for foundational observability.
+*   **Upgrade 600:** Establish `docs/observability/observability_roadmap.md` aligning the foundational roadmap milestones with foundational observability.
 
 ## Phase 2: Core Intelligence & Feature Development
 
@@ -256,6 +356,106 @@ This phase focuses on building out the core AI capabilities, enhancing system in
 *   **Upgrade 198:** Implement `automation/workflow_engine/state_persistence.py` storing progress in case of restarts.
 *   **Upgrade 199:** Provide `search/ui/relevance_feedback.ts` to collect user feedback on search answers.
 *   **Upgrade 200:** Add `iot/voice_announcements.py` enabling the assistant to speak through connected speakers.
+*   **Upgrade 601:** Add `domains/audio_processing/audio_coordinator.py` acting as a coordinator that deepens audio intelligence pipelines.
+*   **Upgrade 602:** Introduce `domains/audio_processing/audio_optimizer.py` optimizing pipelines to enhance audio intelligence pipelines.
+*   **Upgrade 603:** Implement `domains/audio_processing/audio_bridge.py` bridging supporting services to expand audio intelligence pipelines.
+*   **Upgrade 604:** Create `domains/audio_processing/audio_trainer.py` training datasets that accelerate audio intelligence pipelines.
+*   **Upgrade 605:** Publish `domains/audio_processing/audio_analyzer.py` analyzing telemetry streams to refine audio intelligence pipelines.
+*   **Upgrade 606:** Provide `domains/audio_processing/audio_adapter.py` adapting integrations so audio intelligence pipelines can scale.
+*   **Upgrade 607:** Ship `domains/audio_processing/audio_studio.py` delivering studio tooling for teams to shape audio intelligence pipelines.
+*   **Upgrade 608:** Build `domains/audio_processing/audio_monitor.py` monitoring execution quality to safeguard audio intelligence pipelines.
+*   **Upgrade 609:** Deliver `domains/audio_processing/audio_toolkit.py` packaging toolkit assets that boost audio intelligence pipelines.
+*   **Upgrade 610:** Launch `domains/audio_processing/audio_blueprint.py` documenting blueprints that future-proof audio intelligence pipelines.
+*   **Upgrade 611:** Add `domains/natural_language_processing/language_coordinator.py` acting as a coordinator that deepens natural language orchestration.
+*   **Upgrade 612:** Introduce `domains/natural_language_processing/language_optimizer.py` optimizing pipelines to enhance natural language orchestration.
+*   **Upgrade 613:** Implement `domains/natural_language_processing/language_bridge.py` bridging supporting services to expand natural language orchestration.
+*   **Upgrade 614:** Create `domains/natural_language_processing/language_trainer.py` training datasets that accelerate natural language orchestration.
+*   **Upgrade 615:** Publish `domains/natural_language_processing/language_analyzer.py` analyzing telemetry streams to refine natural language orchestration.
+*   **Upgrade 616:** Provide `domains/natural_language_processing/language_adapter.py` adapting integrations so natural language orchestration can scale.
+*   **Upgrade 617:** Ship `domains/natural_language_processing/language_studio.py` delivering studio tooling for teams to shape natural language orchestration.
+*   **Upgrade 618:** Build `domains/natural_language_processing/language_monitor.py` monitoring execution quality to safeguard natural language orchestration.
+*   **Upgrade 619:** Deliver `domains/natural_language_processing/language_toolkit.py` packaging toolkit assets that boost natural language orchestration.
+*   **Upgrade 620:** Launch `domains/natural_language_processing/language_blueprint.py` documenting blueprints that future-proof natural language orchestration.
+*   **Upgrade 621:** Add `domains/computer_vision/vision_coordinator.py` acting as a coordinator that deepens computer vision understanding.
+*   **Upgrade 622:** Introduce `domains/computer_vision/vision_optimizer.py` optimizing pipelines to enhance computer vision understanding.
+*   **Upgrade 623:** Implement `domains/computer_vision/vision_bridge.py` bridging supporting services to expand computer vision understanding.
+*   **Upgrade 624:** Create `domains/computer_vision/vision_trainer.py` training datasets that accelerate computer vision understanding.
+*   **Upgrade 625:** Publish `domains/computer_vision/vision_analyzer.py` analyzing telemetry streams to refine computer vision understanding.
+*   **Upgrade 626:** Provide `domains/computer_vision/vision_adapter.py` adapting integrations so computer vision understanding can scale.
+*   **Upgrade 627:** Ship `domains/computer_vision/vision_studio.py` delivering studio tooling for teams to shape computer vision understanding.
+*   **Upgrade 628:** Build `domains/computer_vision/vision_monitor.py` monitoring execution quality to safeguard computer vision understanding.
+*   **Upgrade 629:** Deliver `domains/computer_vision/vision_toolkit.py` packaging toolkit assets that boost computer vision understanding.
+*   **Upgrade 630:** Launch `domains/computer_vision/vision_blueprint.py` documenting blueprints that future-proof computer vision understanding.
+*   **Upgrade 631:** Add `windows_ai/system_controls/windows_coordinator.py` acting as a coordinator that deepens Windows system control integrations.
+*   **Upgrade 632:** Introduce `windows_ai/system_controls/windows_optimizer.py` optimizing pipelines to enhance Windows system control integrations.
+*   **Upgrade 633:** Implement `windows_ai/system_controls/windows_bridge.py` bridging supporting services to expand Windows system control integrations.
+*   **Upgrade 634:** Create `windows_ai/system_controls/windows_trainer.py` training datasets that accelerate Windows system control integrations.
+*   **Upgrade 635:** Publish `windows_ai/system_controls/windows_analyzer.py` analyzing telemetry streams to refine Windows system control integrations.
+*   **Upgrade 636:** Provide `windows_ai/system_controls/windows_adapter.py` adapting integrations so Windows system control integrations can scale.
+*   **Upgrade 637:** Ship `windows_ai/system_controls/windows_studio.py` delivering studio tooling for teams to shape Windows system control integrations.
+*   **Upgrade 638:** Build `windows_ai/system_controls/windows_monitor.py` monitoring execution quality to safeguard Windows system control integrations.
+*   **Upgrade 639:** Deliver `windows_ai/system_controls/windows_toolkit.py` packaging toolkit assets that boost Windows system control integrations.
+*   **Upgrade 640:** Launch `windows_ai/system_controls/windows_blueprint.py` documenting blueprints that future-proof Windows system control integrations.
+*   **Upgrade 641:** Add `agenthub/agenthub_coordinator.py` acting as a coordinator that deepens core orchestration intelligence.
+*   **Upgrade 642:** Introduce `agenthub/agenthub_optimizer.py` optimizing pipelines to enhance core orchestration intelligence.
+*   **Upgrade 643:** Implement `agenthub/agenthub_bridge.py` bridging supporting services to expand core orchestration intelligence.
+*   **Upgrade 644:** Create `agenthub/agenthub_trainer.py` training datasets that accelerate core orchestration intelligence.
+*   **Upgrade 645:** Publish `agenthub/agenthub_analyzer.py` analyzing telemetry streams to refine core orchestration intelligence.
+*   **Upgrade 646:** Provide `agenthub/agenthub_adapter.py` adapting integrations so core orchestration intelligence can scale.
+*   **Upgrade 647:** Ship `agenthub/agenthub_studio.py` delivering studio tooling for teams to shape core orchestration intelligence.
+*   **Upgrade 648:** Build `agenthub/agenthub_monitor.py` monitoring execution quality to safeguard core orchestration intelligence.
+*   **Upgrade 649:** Deliver `agenthub/agenthub_toolkit.py` packaging toolkit assets that boost core orchestration intelligence.
+*   **Upgrade 650:** Launch `agenthub/agenthub_blueprint.py` documenting blueprints that future-proof core orchestration intelligence.
+*   **Upgrade 651:** Add `automation/automation_coordinator.py` acting as a coordinator that deepens workflow execution depth.
+*   **Upgrade 652:** Introduce `automation/automation_optimizer.py` optimizing pipelines to enhance workflow execution depth.
+*   **Upgrade 653:** Implement `automation/automation_bridge.py` bridging supporting services to expand workflow execution depth.
+*   **Upgrade 654:** Create `automation/automation_trainer.py` training datasets that accelerate workflow execution depth.
+*   **Upgrade 655:** Publish `automation/automation_analyzer.py` analyzing telemetry streams to refine workflow execution depth.
+*   **Upgrade 656:** Provide `automation/automation_adapter.py` adapting integrations so workflow execution depth can scale.
+*   **Upgrade 657:** Ship `automation/automation_studio.py` delivering studio tooling for teams to shape workflow execution depth.
+*   **Upgrade 658:** Build `automation/automation_monitor.py` monitoring execution quality to safeguard workflow execution depth.
+*   **Upgrade 659:** Deliver `automation/automation_toolkit.py` packaging toolkit assets that boost workflow execution depth.
+*   **Upgrade 660:** Launch `automation/automation_blueprint.py` documenting blueprints that future-proof workflow execution depth.
+*   **Upgrade 661:** Add `search/search_coordinator.py` acting as a coordinator that deepens semantic retrieval capabilities.
+*   **Upgrade 662:** Introduce `search/search_optimizer.py` optimizing pipelines to enhance semantic retrieval capabilities.
+*   **Upgrade 663:** Implement `search/search_bridge.py` bridging supporting services to expand semantic retrieval capabilities.
+*   **Upgrade 664:** Create `search/search_trainer.py` training datasets that accelerate semantic retrieval capabilities.
+*   **Upgrade 665:** Publish `search/search_analyzer.py` analyzing telemetry streams to refine semantic retrieval capabilities.
+*   **Upgrade 666:** Provide `search/search_adapter.py` adapting integrations so semantic retrieval capabilities can scale.
+*   **Upgrade 667:** Ship `search/search_studio.py` delivering studio tooling for teams to shape semantic retrieval capabilities.
+*   **Upgrade 668:** Build `search/search_monitor.py` monitoring execution quality to safeguard semantic retrieval capabilities.
+*   **Upgrade 669:** Deliver `search/search_toolkit.py` packaging toolkit assets that boost semantic retrieval capabilities.
+*   **Upgrade 670:** Launch `search/search_blueprint.py` documenting blueprints that future-proof semantic retrieval capabilities.
+*   **Upgrade 671:** Add `gui/src/components/gui_coordinator.vue` acting as a coordinator that deepens immersive user interaction.
+*   **Upgrade 672:** Introduce `gui/src/components/gui_optimizer.vue` optimizing pipelines to enhance immersive user interaction.
+*   **Upgrade 673:** Implement `gui/src/components/gui_bridge.vue` bridging supporting services to expand immersive user interaction.
+*   **Upgrade 674:** Create `gui/src/components/gui_trainer.vue` training datasets that accelerate immersive user interaction.
+*   **Upgrade 675:** Publish `gui/src/components/gui_analyzer.vue` analyzing telemetry streams to refine immersive user interaction.
+*   **Upgrade 676:** Provide `gui/src/components/gui_adapter.vue` adapting integrations so immersive user interaction can scale.
+*   **Upgrade 677:** Ship `gui/src/components/gui_studio.vue` delivering studio tooling for teams to shape immersive user interaction.
+*   **Upgrade 678:** Build `gui/src/components/gui_monitor.vue` monitoring execution quality to safeguard immersive user interaction.
+*   **Upgrade 679:** Deliver `gui/src/components/gui_toolkit.vue` packaging toolkit assets that boost immersive user interaction.
+*   **Upgrade 680:** Launch `gui/src/components/gui_blueprint.vue` documenting blueprints that future-proof immersive user interaction.
+*   **Upgrade 681:** Add `mobile/mobile_coordinator.ts` acting as a coordinator that deepens cross-device experiences.
+*   **Upgrade 682:** Introduce `mobile/mobile_optimizer.ts` optimizing pipelines to enhance cross-device experiences.
+*   **Upgrade 683:** Implement `mobile/mobile_bridge.ts` bridging supporting services to expand cross-device experiences.
+*   **Upgrade 684:** Create `mobile/mobile_trainer.ts` training datasets that accelerate cross-device experiences.
+*   **Upgrade 685:** Publish `mobile/mobile_analyzer.ts` analyzing telemetry streams to refine cross-device experiences.
+*   **Upgrade 686:** Provide `mobile/mobile_adapter.ts` adapting integrations so cross-device experiences can scale.
+*   **Upgrade 687:** Ship `mobile/mobile_studio.ts` delivering studio tooling for teams to shape cross-device experiences.
+*   **Upgrade 688:** Build `mobile/mobile_monitor.ts` monitoring execution quality to safeguard cross-device experiences.
+*   **Upgrade 689:** Deliver `mobile/mobile_toolkit.ts` packaging toolkit assets that boost cross-device experiences.
+*   **Upgrade 690:** Launch `mobile/mobile_blueprint.ts` documenting blueprints that future-proof cross-device experiences.
+*   **Upgrade 691:** Add `iot/iot_coordinator.py` acting as a coordinator that deepens device orchestration reach.
+*   **Upgrade 692:** Introduce `iot/iot_optimizer.py` optimizing pipelines to enhance device orchestration reach.
+*   **Upgrade 693:** Implement `iot/iot_bridge.py` bridging supporting services to expand device orchestration reach.
+*   **Upgrade 694:** Create `iot/iot_trainer.py` training datasets that accelerate device orchestration reach.
+*   **Upgrade 695:** Publish `iot/iot_analyzer.py` analyzing telemetry streams to refine device orchestration reach.
+*   **Upgrade 696:** Provide `iot/iot_adapter.py` adapting integrations so device orchestration reach can scale.
+*   **Upgrade 697:** Ship `iot/iot_studio.py` delivering studio tooling for teams to shape device orchestration reach.
+*   **Upgrade 698:** Build `iot/iot_monitor.py` monitoring execution quality to safeguard device orchestration reach.
+*   **Upgrade 699:** Deliver `iot/iot_toolkit.py` packaging toolkit assets that boost device orchestration reach.
+*   **Upgrade 700:** Launch `iot/iot_blueprint.py` documenting blueprints that future-proof device orchestration reach.
 
 ## Phase 3: Advanced Intelligence & User Experience
 
@@ -388,6 +588,106 @@ This phase deepens the AI's intelligence, focuses on proactive assistance, and r
 *   **Upgrade 298:** Add `agenthub/monitoring/notification_rate_controller.py` throttling proactive prompts.
 *   **Upgrade 299:** Implement `agenthub/proactivity/sequential_planner.py` orchestrating multi-step journeys.
 *   **Upgrade 300:** Provide `agenthub/memory/context_sharing_controls.py` letting users export or share selected memory slices.
+*   **Upgrade 701:** Add `agenthub/memory/memory_expander.py` expanding instrumentation that accelerates contextual memory evolution.
+*   **Upgrade 702:** Introduce `agenthub/memory/memory_guardian.py` guarding critical pathways that protect contextual memory evolution.
+*   **Upgrade 703:** Implement `agenthub/memory/memory_atlas.py` mapping the signal flows that sustain contextual memory evolution.
+*   **Upgrade 704:** Create `agenthub/memory/memory_mentor.py` mentoring users with guidance that elevates contextual memory evolution.
+*   **Upgrade 705:** Publish `agenthub/memory/memory_insight.py` extracting insights that clarify contextual memory evolution.
+*   **Upgrade 706:** Provide `agenthub/memory/memory_cadence.py` establishing cadences that keep contextual memory evolution fresh.
+*   **Upgrade 707:** Ship `agenthub/memory/memory_compass.py` acting as a compass so teams can navigate contextual memory evolution.
+*   **Upgrade 708:** Build `agenthub/memory/memory_canvas.py` providing canvases where people can refine contextual memory evolution.
+*   **Upgrade 709:** Deliver `agenthub/memory/memory_ledger.py` recording decisions that influence contextual memory evolution.
+*   **Upgrade 710:** Curate `agenthub/memory/memory_accelerator.py` accelerating experiments that push contextual memory evolution forward.
+*   **Upgrade 711:** Add `agenthub/proactivity/proactivity_expander.py` expanding instrumentation that accelerates proactive guidance intelligence.
+*   **Upgrade 712:** Introduce `agenthub/proactivity/proactivity_guardian.py` guarding critical pathways that protect proactive guidance intelligence.
+*   **Upgrade 713:** Implement `agenthub/proactivity/proactivity_atlas.py` mapping the signal flows that sustain proactive guidance intelligence.
+*   **Upgrade 714:** Create `agenthub/proactivity/proactivity_mentor.py` mentoring users with guidance that elevates proactive guidance intelligence.
+*   **Upgrade 715:** Publish `agenthub/proactivity/proactivity_insight.py` extracting insights that clarify proactive guidance intelligence.
+*   **Upgrade 716:** Provide `agenthub/proactivity/proactivity_cadence.py` establishing cadences that keep proactive guidance intelligence fresh.
+*   **Upgrade 717:** Ship `agenthub/proactivity/proactivity_compass.py` acting as a compass so teams can navigate proactive guidance intelligence.
+*   **Upgrade 718:** Build `agenthub/proactivity/proactivity_canvas.py` providing canvases where people can refine proactive guidance intelligence.
+*   **Upgrade 719:** Deliver `agenthub/proactivity/proactivity_ledger.py` recording decisions that influence proactive guidance intelligence.
+*   **Upgrade 720:** Curate `agenthub/proactivity/proactivity_accelerator.py` accelerating experiments that push proactive guidance intelligence forward.
+*   **Upgrade 721:** Add `agenthub/monitoring/monitoring_expander.py` expanding instrumentation that accelerates situational awareness.
+*   **Upgrade 722:** Introduce `agenthub/monitoring/monitoring_guardian.py` guarding critical pathways that protect situational awareness.
+*   **Upgrade 723:** Implement `agenthub/monitoring/monitoring_atlas.py` mapping the signal flows that sustain situational awareness.
+*   **Upgrade 724:** Create `agenthub/monitoring/monitoring_mentor.py` mentoring users with guidance that elevates situational awareness.
+*   **Upgrade 725:** Publish `agenthub/monitoring/monitoring_insight.py` extracting insights that clarify situational awareness.
+*   **Upgrade 726:** Provide `agenthub/monitoring/monitoring_cadence.py` establishing cadences that keep situational awareness fresh.
+*   **Upgrade 727:** Ship `agenthub/monitoring/monitoring_compass.py` acting as a compass so teams can navigate situational awareness.
+*   **Upgrade 728:** Build `agenthub/monitoring/monitoring_canvas.py` providing canvases where people can refine situational awareness.
+*   **Upgrade 729:** Deliver `agenthub/monitoring/monitoring_ledger.py` recording decisions that influence situational awareness.
+*   **Upgrade 730:** Curate `agenthub/monitoring/monitoring_accelerator.py` accelerating experiments that push situational awareness forward.
+*   **Upgrade 731:** Add `agenthub/explanations/explanations_expander.py` expanding instrumentation that accelerates explainability depth.
+*   **Upgrade 732:** Introduce `agenthub/explanations/explanations_guardian.py` guarding critical pathways that protect explainability depth.
+*   **Upgrade 733:** Implement `agenthub/explanations/explanations_atlas.py` mapping the signal flows that sustain explainability depth.
+*   **Upgrade 734:** Create `agenthub/explanations/explanations_mentor.py` mentoring users with guidance that elevates explainability depth.
+*   **Upgrade 735:** Publish `agenthub/explanations/explanations_insight.py` extracting insights that clarify explainability depth.
+*   **Upgrade 736:** Provide `agenthub/explanations/explanations_cadence.py` establishing cadences that keep explainability depth fresh.
+*   **Upgrade 737:** Ship `agenthub/explanations/explanations_compass.py` acting as a compass so teams can navigate explainability depth.
+*   **Upgrade 738:** Build `agenthub/explanations/explanations_canvas.py` providing canvases where people can refine explainability depth.
+*   **Upgrade 739:** Deliver `agenthub/explanations/explanations_ledger.py` recording decisions that influence explainability depth.
+*   **Upgrade 740:** Curate `agenthub/explanations/explanations_accelerator.py` accelerating experiments that push explainability depth forward.
+*   **Upgrade 741:** Add `agenthub/feedback/feedback_expander.py` expanding instrumentation that accelerates learning from user feedback.
+*   **Upgrade 742:** Introduce `agenthub/feedback/feedback_guardian.py` guarding critical pathways that protect learning from user feedback.
+*   **Upgrade 743:** Implement `agenthub/feedback/feedback_atlas.py` mapping the signal flows that sustain learning from user feedback.
+*   **Upgrade 744:** Create `agenthub/feedback/feedback_mentor.py` mentoring users with guidance that elevates learning from user feedback.
+*   **Upgrade 745:** Publish `agenthub/feedback/feedback_insight.py` extracting insights that clarify learning from user feedback.
+*   **Upgrade 746:** Provide `agenthub/feedback/feedback_cadence.py` establishing cadences that keep learning from user feedback fresh.
+*   **Upgrade 747:** Ship `agenthub/feedback/feedback_compass.py` acting as a compass so teams can navigate learning from user feedback.
+*   **Upgrade 748:** Build `agenthub/feedback/feedback_canvas.py` providing canvases where people can refine learning from user feedback.
+*   **Upgrade 749:** Deliver `agenthub/feedback/feedback_ledger.py` recording decisions that influence learning from user feedback.
+*   **Upgrade 750:** Curate `agenthub/feedback/feedback_accelerator.py` accelerating experiments that push learning from user feedback forward.
+*   **Upgrade 751:** Add `gui/src/components/transparency_expander.vue` expanding instrumentation that accelerates transparency surfaces.
+*   **Upgrade 752:** Introduce `gui/src/components/transparency_guardian.vue` guarding critical pathways that protect transparency surfaces.
+*   **Upgrade 753:** Implement `gui/src/components/transparency_atlas.vue` mapping the signal flows that sustain transparency surfaces.
+*   **Upgrade 754:** Create `gui/src/components/transparency_mentor.vue` mentoring users with guidance that elevates transparency surfaces.
+*   **Upgrade 755:** Publish `gui/src/components/transparency_insight.vue` extracting insights that clarify transparency surfaces.
+*   **Upgrade 756:** Provide `gui/src/components/transparency_cadence.vue` establishing cadences that keep transparency surfaces fresh.
+*   **Upgrade 757:** Ship `gui/src/components/transparency_compass.vue` acting as a compass so teams can navigate transparency surfaces.
+*   **Upgrade 758:** Build `gui/src/components/transparency_canvas.vue` providing canvases where people can refine transparency surfaces.
+*   **Upgrade 759:** Deliver `gui/src/components/transparency_ledger.vue` recording decisions that influence transparency surfaces.
+*   **Upgrade 760:** Curate `gui/src/components/transparency_accelerator.vue` accelerating experiments that push transparency surfaces forward.
+*   **Upgrade 761:** Add `gui/src/components/personalization_expander.vue` expanding instrumentation that accelerates personalized experiences.
+*   **Upgrade 762:** Introduce `gui/src/components/personalization_guardian.vue` guarding critical pathways that protect personalized experiences.
+*   **Upgrade 763:** Implement `gui/src/components/personalization_atlas.vue` mapping the signal flows that sustain personalized experiences.
+*   **Upgrade 764:** Create `gui/src/components/personalization_mentor.vue` mentoring users with guidance that elevates personalized experiences.
+*   **Upgrade 765:** Publish `gui/src/components/personalization_insight.vue` extracting insights that clarify personalized experiences.
+*   **Upgrade 766:** Provide `gui/src/components/personalization_cadence.vue` establishing cadences that keep personalized experiences fresh.
+*   **Upgrade 767:** Ship `gui/src/components/personalization_compass.vue` acting as a compass so teams can navigate personalized experiences.
+*   **Upgrade 768:** Build `gui/src/components/personalization_canvas.vue` providing canvases where people can refine personalized experiences.
+*   **Upgrade 769:** Deliver `gui/src/components/personalization_ledger.vue` recording decisions that influence personalized experiences.
+*   **Upgrade 770:** Curate `gui/src/components/personalization_accelerator.vue` accelerating experiments that push personalized experiences forward.
+*   **Upgrade 771:** Add `docs/guides/governance_expander.md` expanding instrumentation that accelerates context governance.
+*   **Upgrade 772:** Introduce `docs/guides/governance_guardian.md` guarding critical pathways that protect context governance.
+*   **Upgrade 773:** Implement `docs/guides/governance_atlas.md` mapping the signal flows that sustain context governance.
+*   **Upgrade 774:** Create `docs/guides/governance_mentor.md` mentoring users with guidance that elevates context governance.
+*   **Upgrade 775:** Publish `docs/guides/governance_insight.md` extracting insights that clarify context governance.
+*   **Upgrade 776:** Provide `docs/guides/governance_cadence.md` establishing cadences that keep context governance fresh.
+*   **Upgrade 777:** Ship `docs/guides/governance_compass.md` acting as a compass so teams can navigate context governance.
+*   **Upgrade 778:** Build `docs/guides/governance_canvas.md` providing canvases where people can refine context governance.
+*   **Upgrade 779:** Deliver `docs/guides/governance_ledger.md` recording decisions that influence context governance.
+*   **Upgrade 780:** Curate `docs/guides/governance_accelerator.md` accelerating experiments that push context governance forward.
+*   **Upgrade 781:** Add `agenthub/analytics/analytics_expander.py` expanding instrumentation that accelerates behavioral analytics.
+*   **Upgrade 782:** Introduce `agenthub/analytics/analytics_guardian.py` guarding critical pathways that protect behavioral analytics.
+*   **Upgrade 783:** Implement `agenthub/analytics/analytics_atlas.py` mapping the signal flows that sustain behavioral analytics.
+*   **Upgrade 784:** Create `agenthub/analytics/analytics_mentor.py` mentoring users with guidance that elevates behavioral analytics.
+*   **Upgrade 785:** Publish `agenthub/analytics/analytics_insight.py` extracting insights that clarify behavioral analytics.
+*   **Upgrade 786:** Provide `agenthub/analytics/analytics_cadence.py` establishing cadences that keep behavioral analytics fresh.
+*   **Upgrade 787:** Ship `agenthub/analytics/analytics_compass.py` acting as a compass so teams can navigate behavioral analytics.
+*   **Upgrade 788:** Build `agenthub/analytics/analytics_canvas.py` providing canvases where people can refine behavioral analytics.
+*   **Upgrade 789:** Deliver `agenthub/analytics/analytics_ledger.py` recording decisions that influence behavioral analytics.
+*   **Upgrade 790:** Curate `agenthub/analytics/analytics_accelerator.py` accelerating experiments that push behavioral analytics forward.
+*   **Upgrade 791:** Add `docs/insights/insights_expander.md` expanding instrumentation that accelerates insight sharing.
+*   **Upgrade 792:** Introduce `docs/insights/insights_guardian.md` guarding critical pathways that protect insight sharing.
+*   **Upgrade 793:** Implement `docs/insights/insights_atlas.md` mapping the signal flows that sustain insight sharing.
+*   **Upgrade 794:** Create `docs/insights/insights_mentor.md` mentoring users with guidance that elevates insight sharing.
+*   **Upgrade 795:** Publish `docs/insights/insights_insight.md` extracting insights that clarify insight sharing.
+*   **Upgrade 796:** Provide `docs/insights/insights_cadence.md` establishing cadences that keep insight sharing fresh.
+*   **Upgrade 797:** Ship `docs/insights/insights_compass.md` acting as a compass so teams can navigate insight sharing.
+*   **Upgrade 798:** Build `docs/insights/insights_canvas.md` providing canvases where people can refine insight sharing.
+*   **Upgrade 799:** Deliver `docs/insights/insights_ledger.md` recording decisions that influence insight sharing.
+*   **Upgrade 800:** Curate `docs/insights/insights_accelerator.md` accelerating experiments that push insight sharing forward.
 
 ## Phase 4: Robustness, Security & Deployment
 
@@ -518,6 +818,106 @@ This phase ensures the project is stable, secure, and easily deployable for end-
 *   **Upgrade 398:** Implement `security/monitoring/forensic_snapshot_tool.py` capturing state for investigations.
 *   **Upgrade 399:** Provide `docs/security/sdlc-checklist.md` embedding security into development lifecycle.
 *   **Upgrade 400:** Ship `tests/performance/update_install_duration.py` tracking update installation times.
+*   **Upgrade 801:** Add `tests/performance/tests_performance_sentinel.py` standing up sentinel coverage that reinforces performance hardening.
+*   **Upgrade 802:** Introduce `tests/performance/tests_performance_scanner.py` scanning for weaknesses to close gaps in performance hardening.
+*   **Upgrade 803:** Implement `tests/performance/tests_performance_ledger.py` keeping ledgers that audit performance hardening outcomes.
+*   **Upgrade 804:** Create `tests/performance/tests_performance_workflow.py` defining workflows that operationalize performance hardening.
+*   **Upgrade 805:** Publish `tests/performance/tests_performance_baseline.py` capturing baselines that detect regressions in performance hardening.
+*   **Upgrade 806:** Provide `tests/performance/tests_performance_response.py` documenting response patterns that safeguard performance hardening.
+*   **Upgrade 807:** Ship `tests/performance/tests_performance_guardian.py` guarding critical guardrails that maintain performance hardening.
+*   **Upgrade 808:** Build `tests/performance/tests_performance_exercise.py` codifying exercises that stress-test performance hardening.
+*   **Upgrade 809:** Deliver `tests/performance/tests_performance_telemetry.py` expanding telemetry streams that observe performance hardening.
+*   **Upgrade 810:** Engineer `tests/performance/tests_performance_companion.py` delivering companion tooling that simplifies performance hardening.
+*   **Upgrade 811:** Add `tests/security/tests_security_sentinel.py` standing up sentinel coverage that reinforces security validation.
+*   **Upgrade 812:** Introduce `tests/security/tests_security_scanner.py` scanning for weaknesses to close gaps in security validation.
+*   **Upgrade 813:** Implement `tests/security/tests_security_ledger.py` keeping ledgers that audit security validation outcomes.
+*   **Upgrade 814:** Create `tests/security/tests_security_workflow.py` defining workflows that operationalize security validation.
+*   **Upgrade 815:** Publish `tests/security/tests_security_baseline.py` capturing baselines that detect regressions in security validation.
+*   **Upgrade 816:** Provide `tests/security/tests_security_response.py` documenting response patterns that safeguard security validation.
+*   **Upgrade 817:** Ship `tests/security/tests_security_guardian.py` guarding critical guardrails that maintain security validation.
+*   **Upgrade 818:** Build `tests/security/tests_security_exercise.py` codifying exercises that stress-test security validation.
+*   **Upgrade 819:** Deliver `tests/security/tests_security_telemetry.py` expanding telemetry streams that observe security validation.
+*   **Upgrade 820:** Engineer `tests/security/tests_security_companion.py` delivering companion tooling that simplifies security validation.
+*   **Upgrade 821:** Add `tests/reliability/tests_reliability_sentinel.py` standing up sentinel coverage that reinforces reliability assurance.
+*   **Upgrade 822:** Introduce `tests/reliability/tests_reliability_scanner.py` scanning for weaknesses to close gaps in reliability assurance.
+*   **Upgrade 823:** Implement `tests/reliability/tests_reliability_ledger.py` keeping ledgers that audit reliability assurance outcomes.
+*   **Upgrade 824:** Create `tests/reliability/tests_reliability_workflow.py` defining workflows that operationalize reliability assurance.
+*   **Upgrade 825:** Publish `tests/reliability/tests_reliability_baseline.py` capturing baselines that detect regressions in reliability assurance.
+*   **Upgrade 826:** Provide `tests/reliability/tests_reliability_response.py` documenting response patterns that safeguard reliability assurance.
+*   **Upgrade 827:** Ship `tests/reliability/tests_reliability_guardian.py` guarding critical guardrails that maintain reliability assurance.
+*   **Upgrade 828:** Build `tests/reliability/tests_reliability_exercise.py` codifying exercises that stress-test reliability assurance.
+*   **Upgrade 829:** Deliver `tests/reliability/tests_reliability_telemetry.py` expanding telemetry streams that observe reliability assurance.
+*   **Upgrade 830:** Engineer `tests/reliability/tests_reliability_companion.py` delivering companion tooling that simplifies reliability assurance.
+*   **Upgrade 831:** Add `tests/integration/tests_integration_sentinel.py` standing up sentinel coverage that reinforces integration guarantees.
+*   **Upgrade 832:** Introduce `tests/integration/tests_integration_scanner.py` scanning for weaknesses to close gaps in integration guarantees.
+*   **Upgrade 833:** Implement `tests/integration/tests_integration_ledger.py` keeping ledgers that audit integration guarantees outcomes.
+*   **Upgrade 834:** Create `tests/integration/tests_integration_workflow.py` defining workflows that operationalize integration guarantees.
+*   **Upgrade 835:** Publish `tests/integration/tests_integration_baseline.py` capturing baselines that detect regressions in integration guarantees.
+*   **Upgrade 836:** Provide `tests/integration/tests_integration_response.py` documenting response patterns that safeguard integration guarantees.
+*   **Upgrade 837:** Ship `tests/integration/tests_integration_guardian.py` guarding critical guardrails that maintain integration guarantees.
+*   **Upgrade 838:** Build `tests/integration/tests_integration_exercise.py` codifying exercises that stress-test integration guarantees.
+*   **Upgrade 839:** Deliver `tests/integration/tests_integration_telemetry.py` expanding telemetry streams that observe integration guarantees.
+*   **Upgrade 840:** Engineer `tests/integration/tests_integration_companion.py` delivering companion tooling that simplifies integration guarantees.
+*   **Upgrade 841:** Add `security/monitoring/security_monitoring_sentinel.py` standing up sentinel coverage that reinforces security telemetry.
+*   **Upgrade 842:** Introduce `security/monitoring/security_monitoring_scanner.py` scanning for weaknesses to close gaps in security telemetry.
+*   **Upgrade 843:** Implement `security/monitoring/security_monitoring_ledger.py` keeping ledgers that audit security telemetry outcomes.
+*   **Upgrade 844:** Create `security/monitoring/security_monitoring_workflow.py` defining workflows that operationalize security telemetry.
+*   **Upgrade 845:** Publish `security/monitoring/security_monitoring_baseline.py` capturing baselines that detect regressions in security telemetry.
+*   **Upgrade 846:** Provide `security/monitoring/security_monitoring_response.py` documenting response patterns that safeguard security telemetry.
+*   **Upgrade 847:** Ship `security/monitoring/security_monitoring_guardian.py` guarding critical guardrails that maintain security telemetry.
+*   **Upgrade 848:** Build `security/monitoring/security_monitoring_exercise.py` codifying exercises that stress-test security telemetry.
+*   **Upgrade 849:** Deliver `security/monitoring/security_monitoring_telemetry.py` expanding telemetry streams that observe security telemetry.
+*   **Upgrade 850:** Engineer `security/monitoring/security_monitoring_companion.py` delivering companion tooling that simplifies security telemetry.
+*   **Upgrade 851:** Add `security/policies/security_policies_sentinel.md` standing up sentinel coverage that reinforces policy governance.
+*   **Upgrade 852:** Introduce `security/policies/security_policies_scanner.md` scanning for weaknesses to close gaps in policy governance.
+*   **Upgrade 853:** Implement `security/policies/security_policies_ledger.md` keeping ledgers that audit policy governance outcomes.
+*   **Upgrade 854:** Create `security/policies/security_policies_workflow.md` defining workflows that operationalize policy governance.
+*   **Upgrade 855:** Publish `security/policies/security_policies_baseline.md` capturing baselines that detect regressions in policy governance.
+*   **Upgrade 856:** Provide `security/policies/security_policies_response.md` documenting response patterns that safeguard policy governance.
+*   **Upgrade 857:** Ship `security/policies/security_policies_guardian.md` guarding critical guardrails that maintain policy governance.
+*   **Upgrade 858:** Build `security/policies/security_policies_exercise.md` codifying exercises that stress-test policy governance.
+*   **Upgrade 859:** Deliver `security/policies/security_policies_telemetry.md` expanding telemetry streams that observe policy governance.
+*   **Upgrade 860:** Engineer `security/policies/security_policies_companion.md` delivering companion tooling that simplifies policy governance.
+*   **Upgrade 861:** Add `installer/installer_sentinel.ps1` standing up sentinel coverage that reinforces installer resilience.
+*   **Upgrade 862:** Introduce `installer/installer_scanner.ps1` scanning for weaknesses to close gaps in installer resilience.
+*   **Upgrade 863:** Implement `installer/installer_ledger.ps1` keeping ledgers that audit installer resilience outcomes.
+*   **Upgrade 864:** Create `installer/installer_workflow.ps1` defining workflows that operationalize installer resilience.
+*   **Upgrade 865:** Publish `installer/installer_baseline.ps1` capturing baselines that detect regressions in installer resilience.
+*   **Upgrade 866:** Provide `installer/installer_response.ps1` documenting response patterns that safeguard installer resilience.
+*   **Upgrade 867:** Ship `installer/installer_guardian.ps1` guarding critical guardrails that maintain installer resilience.
+*   **Upgrade 868:** Build `installer/installer_exercise.ps1` codifying exercises that stress-test installer resilience.
+*   **Upgrade 869:** Deliver `installer/installer_telemetry.ps1` expanding telemetry streams that observe installer resilience.
+*   **Upgrade 870:** Engineer `installer/installer_companion.ps1` delivering companion tooling that simplifies installer resilience.
+*   **Upgrade 871:** Add `docs/deployment/docs_deployment_sentinel.md` standing up sentinel coverage that reinforces deployment excellence.
+*   **Upgrade 872:** Introduce `docs/deployment/docs_deployment_scanner.md` scanning for weaknesses to close gaps in deployment excellence.
+*   **Upgrade 873:** Implement `docs/deployment/docs_deployment_ledger.md` keeping ledgers that audit deployment excellence outcomes.
+*   **Upgrade 874:** Create `docs/deployment/docs_deployment_workflow.md` defining workflows that operationalize deployment excellence.
+*   **Upgrade 875:** Publish `docs/deployment/docs_deployment_baseline.md` capturing baselines that detect regressions in deployment excellence.
+*   **Upgrade 876:** Provide `docs/deployment/docs_deployment_response.md` documenting response patterns that safeguard deployment excellence.
+*   **Upgrade 877:** Ship `docs/deployment/docs_deployment_guardian.md` guarding critical guardrails that maintain deployment excellence.
+*   **Upgrade 878:** Build `docs/deployment/docs_deployment_exercise.md` codifying exercises that stress-test deployment excellence.
+*   **Upgrade 879:** Deliver `docs/deployment/docs_deployment_telemetry.md` expanding telemetry streams that observe deployment excellence.
+*   **Upgrade 880:** Engineer `docs/deployment/docs_deployment_companion.md` delivering companion tooling that simplifies deployment excellence.
+*   **Upgrade 881:** Add `docs/security/docs_security_sentinel.md` standing up sentinel coverage that reinforces security operations.
+*   **Upgrade 882:** Introduce `docs/security/docs_security_scanner.md` scanning for weaknesses to close gaps in security operations.
+*   **Upgrade 883:** Implement `docs/security/docs_security_ledger.md` keeping ledgers that audit security operations outcomes.
+*   **Upgrade 884:** Create `docs/security/docs_security_workflow.md` defining workflows that operationalize security operations.
+*   **Upgrade 885:** Publish `docs/security/docs_security_baseline.md` capturing baselines that detect regressions in security operations.
+*   **Upgrade 886:** Provide `docs/security/docs_security_response.md` documenting response patterns that safeguard security operations.
+*   **Upgrade 887:** Ship `docs/security/docs_security_guardian.md` guarding critical guardrails that maintain security operations.
+*   **Upgrade 888:** Build `docs/security/docs_security_exercise.md` codifying exercises that stress-test security operations.
+*   **Upgrade 889:** Deliver `docs/security/docs_security_telemetry.md` expanding telemetry streams that observe security operations.
+*   **Upgrade 890:** Engineer `docs/security/docs_security_companion.md` delivering companion tooling that simplifies security operations.
+*   **Upgrade 891:** Add `optimization/optimization_sentinel.py` standing up sentinel coverage that reinforces runtime optimization.
+*   **Upgrade 892:** Introduce `optimization/optimization_scanner.py` scanning for weaknesses to close gaps in runtime optimization.
+*   **Upgrade 893:** Implement `optimization/optimization_ledger.py` keeping ledgers that audit runtime optimization outcomes.
+*   **Upgrade 894:** Create `optimization/optimization_workflow.py` defining workflows that operationalize runtime optimization.
+*   **Upgrade 895:** Publish `optimization/optimization_baseline.py` capturing baselines that detect regressions in runtime optimization.
+*   **Upgrade 896:** Provide `optimization/optimization_response.py` documenting response patterns that safeguard runtime optimization.
+*   **Upgrade 897:** Ship `optimization/optimization_guardian.py` guarding critical guardrails that maintain runtime optimization.
+*   **Upgrade 898:** Build `optimization/optimization_exercise.py` codifying exercises that stress-test runtime optimization.
+*   **Upgrade 899:** Deliver `optimization/optimization_telemetry.py` expanding telemetry streams that observe runtime optimization.
+*   **Upgrade 900:** Engineer `optimization/optimization_companion.py` delivering companion tooling that simplifies runtime optimization.
 
 ## Phase 5: Expansion, Ecosystem & Future Growth
 
@@ -637,6 +1037,106 @@ This final phase looks towards the long-term growth of `Windows-AI`, focusing on
 *   **Upgrade 498:** Implement `plugins/marketplace/ui/contributor_profile.vue` showcasing plugin authors.
 *   **Upgrade 499:** Provide `model_discovery/providers/model_signature_verifier.py` validating signatures on downloaded artifacts.
 *   **Upgrade 500:** Ship `community/portal/roadmap-milestones.md` highlighting long-term expansion milestones.
+*   **Upgrade 901:** Add `plugins/sdk/plugins_sdk_guide.md` publishing guides that expand plugin development acceleration.
+*   **Upgrade 902:** Introduce `plugins/sdk/plugins_sdk_catalog.md` curating catalogs that highlight plugin development acceleration.
+*   **Upgrade 903:** Implement `plugins/sdk/plugins_sdk_accelerator.md` launching accelerators that amplify plugin development acceleration.
+*   **Upgrade 904:** Create `plugins/sdk/plugins_sdk_exchange.md` building exchanges that connect stakeholders around plugin development acceleration.
+*   **Upgrade 905:** Publish `plugins/sdk/plugins_sdk_hub.md` establishing hubs where contributors gather for plugin development acceleration.
+*   **Upgrade 906:** Provide `plugins/sdk/plugins_sdk_navigator.md` delivering navigators that simplify plugin development acceleration.
+*   **Upgrade 907:** Ship `plugins/sdk/plugins_sdk_incubator.md` incubating initiatives that nurture plugin development acceleration.
+*   **Upgrade 908:** Build `plugins/sdk/plugins_sdk_brief.md` issuing briefs that communicate the state of plugin development acceleration.
+*   **Upgrade 909:** Deliver `plugins/sdk/plugins_sdk_playbook.md` assembling playbooks that operationalize plugin development acceleration.
+*   **Upgrade 910:** Launch `plugins/sdk/plugins_sdk_dashboard.md` shipping dashboards that visualize plugin development acceleration.
+*   **Upgrade 911:** Add `plugins/marketplace/plugins_marketplace_guide.md` publishing guides that expand marketplace growth.
+*   **Upgrade 912:** Introduce `plugins/marketplace/plugins_marketplace_catalog.md` curating catalogs that highlight marketplace growth.
+*   **Upgrade 913:** Implement `plugins/marketplace/plugins_marketplace_accelerator.md` launching accelerators that amplify marketplace growth.
+*   **Upgrade 914:** Create `plugins/marketplace/plugins_marketplace_exchange.md` building exchanges that connect stakeholders around marketplace growth.
+*   **Upgrade 915:** Publish `plugins/marketplace/plugins_marketplace_hub.md` establishing hubs where contributors gather for marketplace growth.
+*   **Upgrade 916:** Provide `plugins/marketplace/plugins_marketplace_navigator.md` delivering navigators that simplify marketplace growth.
+*   **Upgrade 917:** Ship `plugins/marketplace/plugins_marketplace_incubator.md` incubating initiatives that nurture marketplace growth.
+*   **Upgrade 918:** Build `plugins/marketplace/plugins_marketplace_brief.md` issuing briefs that communicate the state of marketplace growth.
+*   **Upgrade 919:** Deliver `plugins/marketplace/plugins_marketplace_playbook.md` assembling playbooks that operationalize marketplace growth.
+*   **Upgrade 920:** Launch `plugins/marketplace/plugins_marketplace_dashboard.md` shipping dashboards that visualize marketplace growth.
+*   **Upgrade 921:** Add `plugins/testing/plugins_testing_guide.py` publishing guides that expand plugin quality assurance.
+*   **Upgrade 922:** Introduce `plugins/testing/plugins_testing_catalog.py` curating catalogs that highlight plugin quality assurance.
+*   **Upgrade 923:** Implement `plugins/testing/plugins_testing_accelerator.py` launching accelerators that amplify plugin quality assurance.
+*   **Upgrade 924:** Create `plugins/testing/plugins_testing_exchange.py` building exchanges that connect stakeholders around plugin quality assurance.
+*   **Upgrade 925:** Publish `plugins/testing/plugins_testing_hub.py` establishing hubs where contributors gather for plugin quality assurance.
+*   **Upgrade 926:** Provide `plugins/testing/plugins_testing_navigator.py` delivering navigators that simplify plugin quality assurance.
+*   **Upgrade 927:** Ship `plugins/testing/plugins_testing_incubator.py` incubating initiatives that nurture plugin quality assurance.
+*   **Upgrade 928:** Build `plugins/testing/plugins_testing_brief.py` issuing briefs that communicate the state of plugin quality assurance.
+*   **Upgrade 929:** Deliver `plugins/testing/plugins_testing_playbook.py` assembling playbooks that operationalize plugin quality assurance.
+*   **Upgrade 930:** Launch `plugins/testing/plugins_testing_dashboard.py` shipping dashboards that visualize plugin quality assurance.
+*   **Upgrade 931:** Add `model_discovery/providers/model_catalog_guide.py` publishing guides that expand model discovery breadth.
+*   **Upgrade 932:** Introduce `model_discovery/providers/model_catalog_catalog.py` curating catalogs that highlight model discovery breadth.
+*   **Upgrade 933:** Implement `model_discovery/providers/model_catalog_accelerator.py` launching accelerators that amplify model discovery breadth.
+*   **Upgrade 934:** Create `model_discovery/providers/model_catalog_exchange.py` building exchanges that connect stakeholders around model discovery breadth.
+*   **Upgrade 935:** Publish `model_discovery/providers/model_catalog_hub.py` establishing hubs where contributors gather for model discovery breadth.
+*   **Upgrade 936:** Provide `model_discovery/providers/model_catalog_navigator.py` delivering navigators that simplify model discovery breadth.
+*   **Upgrade 937:** Ship `model_discovery/providers/model_catalog_incubator.py` incubating initiatives that nurture model discovery breadth.
+*   **Upgrade 938:** Build `model_discovery/providers/model_catalog_brief.py` issuing briefs that communicate the state of model discovery breadth.
+*   **Upgrade 939:** Deliver `model_discovery/providers/model_catalog_playbook.py` assembling playbooks that operationalize model discovery breadth.
+*   **Upgrade 940:** Launch `model_discovery/providers/model_catalog_dashboard.py` shipping dashboards that visualize model discovery breadth.
+*   **Upgrade 941:** Add `model_discovery/policies/model_policy_guide.md` publishing guides that expand model governance.
+*   **Upgrade 942:** Introduce `model_discovery/policies/model_policy_catalog.md` curating catalogs that highlight model governance.
+*   **Upgrade 943:** Implement `model_discovery/policies/model_policy_accelerator.md` launching accelerators that amplify model governance.
+*   **Upgrade 944:** Create `model_discovery/policies/model_policy_exchange.md` building exchanges that connect stakeholders around model governance.
+*   **Upgrade 945:** Publish `model_discovery/policies/model_policy_hub.md` establishing hubs where contributors gather for model governance.
+*   **Upgrade 946:** Provide `model_discovery/policies/model_policy_navigator.md` delivering navigators that simplify model governance.
+*   **Upgrade 947:** Ship `model_discovery/policies/model_policy_incubator.md` incubating initiatives that nurture model governance.
+*   **Upgrade 948:** Build `model_discovery/policies/model_policy_brief.md` issuing briefs that communicate the state of model governance.
+*   **Upgrade 949:** Deliver `model_discovery/policies/model_policy_playbook.md` assembling playbooks that operationalize model governance.
+*   **Upgrade 950:** Launch `model_discovery/policies/model_policy_dashboard.md` shipping dashboards that visualize model governance.
+*   **Upgrade 951:** Add `community/portal/community_portal_guide.md` publishing guides that expand community storytelling.
+*   **Upgrade 952:** Introduce `community/portal/community_portal_catalog.md` curating catalogs that highlight community storytelling.
+*   **Upgrade 953:** Implement `community/portal/community_portal_accelerator.md` launching accelerators that amplify community storytelling.
+*   **Upgrade 954:** Create `community/portal/community_portal_exchange.md` building exchanges that connect stakeholders around community storytelling.
+*   **Upgrade 955:** Publish `community/portal/community_portal_hub.md` establishing hubs where contributors gather for community storytelling.
+*   **Upgrade 956:** Provide `community/portal/community_portal_navigator.md` delivering navigators that simplify community storytelling.
+*   **Upgrade 957:** Ship `community/portal/community_portal_incubator.md` incubating initiatives that nurture community storytelling.
+*   **Upgrade 958:** Build `community/portal/community_portal_brief.md` issuing briefs that communicate the state of community storytelling.
+*   **Upgrade 959:** Deliver `community/portal/community_portal_playbook.md` assembling playbooks that operationalize community storytelling.
+*   **Upgrade 960:** Launch `community/portal/community_portal_dashboard.md` shipping dashboards that visualize community storytelling.
+*   **Upgrade 961:** Add `community/events/community_events_guide.md` publishing guides that expand event programming.
+*   **Upgrade 962:** Introduce `community/events/community_events_catalog.md` curating catalogs that highlight event programming.
+*   **Upgrade 963:** Implement `community/events/community_events_accelerator.md` launching accelerators that amplify event programming.
+*   **Upgrade 964:** Create `community/events/community_events_exchange.md` building exchanges that connect stakeholders around event programming.
+*   **Upgrade 965:** Publish `community/events/community_events_hub.md` establishing hubs where contributors gather for event programming.
+*   **Upgrade 966:** Provide `community/events/community_events_navigator.md` delivering navigators that simplify event programming.
+*   **Upgrade 967:** Ship `community/events/community_events_incubator.md` incubating initiatives that nurture event programming.
+*   **Upgrade 968:** Build `community/events/community_events_brief.md` issuing briefs that communicate the state of event programming.
+*   **Upgrade 969:** Deliver `community/events/community_events_playbook.md` assembling playbooks that operationalize event programming.
+*   **Upgrade 970:** Launch `community/events/community_events_dashboard.md` shipping dashboards that visualize event programming.
+*   **Upgrade 971:** Add `community/feedback/community_feedback_guide.md` publishing guides that expand feedback intelligence.
+*   **Upgrade 972:** Introduce `community/feedback/community_feedback_catalog.md` curating catalogs that highlight feedback intelligence.
+*   **Upgrade 973:** Implement `community/feedback/community_feedback_accelerator.md` launching accelerators that amplify feedback intelligence.
+*   **Upgrade 974:** Create `community/feedback/community_feedback_exchange.md` building exchanges that connect stakeholders around feedback intelligence.
+*   **Upgrade 975:** Publish `community/feedback/community_feedback_hub.md` establishing hubs where contributors gather for feedback intelligence.
+*   **Upgrade 976:** Provide `community/feedback/community_feedback_navigator.md` delivering navigators that simplify feedback intelligence.
+*   **Upgrade 977:** Ship `community/feedback/community_feedback_incubator.md` incubating initiatives that nurture feedback intelligence.
+*   **Upgrade 978:** Build `community/feedback/community_feedback_brief.md` issuing briefs that communicate the state of feedback intelligence.
+*   **Upgrade 979:** Deliver `community/feedback/community_feedback_playbook.md` assembling playbooks that operationalize feedback intelligence.
+*   **Upgrade 980:** Launch `community/feedback/community_feedback_dashboard.md` shipping dashboards that visualize feedback intelligence.
+*   **Upgrade 981:** Add `docs/ecosystem/docs_ecosystem_guide.md` publishing guides that expand ecosystem knowledge.
+*   **Upgrade 982:** Introduce `docs/ecosystem/docs_ecosystem_catalog.md` curating catalogs that highlight ecosystem knowledge.
+*   **Upgrade 983:** Implement `docs/ecosystem/docs_ecosystem_accelerator.md` launching accelerators that amplify ecosystem knowledge.
+*   **Upgrade 984:** Create `docs/ecosystem/docs_ecosystem_exchange.md` building exchanges that connect stakeholders around ecosystem knowledge.
+*   **Upgrade 985:** Publish `docs/ecosystem/docs_ecosystem_hub.md` establishing hubs where contributors gather for ecosystem knowledge.
+*   **Upgrade 986:** Provide `docs/ecosystem/docs_ecosystem_navigator.md` delivering navigators that simplify ecosystem knowledge.
+*   **Upgrade 987:** Ship `docs/ecosystem/docs_ecosystem_incubator.md` incubating initiatives that nurture ecosystem knowledge.
+*   **Upgrade 988:** Build `docs/ecosystem/docs_ecosystem_brief.md` issuing briefs that communicate the state of ecosystem knowledge.
+*   **Upgrade 989:** Deliver `docs/ecosystem/docs_ecosystem_playbook.md` assembling playbooks that operationalize ecosystem knowledge.
+*   **Upgrade 990:** Launch `docs/ecosystem/docs_ecosystem_dashboard.md` shipping dashboards that visualize ecosystem knowledge.
+*   **Upgrade 991:** Add `community/partners/partners_guide.md` publishing guides that expand partner engagement.
+*   **Upgrade 992:** Introduce `community/partners/partners_catalog.md` curating catalogs that highlight partner engagement.
+*   **Upgrade 993:** Implement `community/partners/partners_accelerator.md` launching accelerators that amplify partner engagement.
+*   **Upgrade 994:** Create `community/partners/partners_exchange.md` building exchanges that connect stakeholders around partner engagement.
+*   **Upgrade 995:** Publish `community/partners/partners_hub.md` establishing hubs where contributors gather for partner engagement.
+*   **Upgrade 996:** Provide `community/partners/partners_navigator.md` delivering navigators that simplify partner engagement.
+*   **Upgrade 997:** Ship `community/partners/partners_incubator.md` incubating initiatives that nurture partner engagement.
+*   **Upgrade 998:** Build `community/partners/partners_brief.md` issuing briefs that communicate the state of partner engagement.
+*   **Upgrade 999:** Deliver `community/partners/partners_playbook.md` assembling playbooks that operationalize partner engagement.
+*   **Upgrade 1000:** Launch `community/partners/partners_dashboard.md` shipping dashboards that visualize partner engagement.
 ---
 
 ## New Suggestions for the Roadmap


### PR DESCRIPTION
## Summary
- add 100 new upgrade entries for each roadmap phase to extend the roadmap
- ensure numbering continuity beyond the original items while grouping upgrades by phase themes

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915eecc505483269dae4082f4abfa65)