### PR TITLE
Add Agents management UI + plugin marketplace UX improvements and styling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -139,7 +139,7 @@ Windows AI is a **comprehensive, locally-runnable AI platform for Windows** that
 ### 2.1 GUI Enhancements
 - [x] Electron renderer: markdown rendering for assistant messages (done in previous session)
 - [ ] Plugin marketplace browser in GUI
-- [ ] Agent creation/management wizard
+- [x] Agent creation/management wizard — added Agents tab UI in Electron renderer with create/delete agent flows, task dispatch form, and live stats/list integration
 - [ ] Multi-agent task flow visualization (graph/timeline)
 - [ ] Accessibility improvements (screen reader support, keyboard nav)
 - [ ] Windows Hello biometric login integration

--- a/apps/gui/renderer/index.html
+++ b/apps/gui/renderer/index.html
@@ -36,6 +36,15 @@
         </svg>
         Automation
       </button>
+      <button class="nav-btn" data-tab="agents">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="9" cy="7" r="4"/>
+          <path d="M17 11a4 4 0 1 0 0-8"/>
+          <path d="M3 21v-2a6 6 0 0 1 12 0v2"/>
+          <path d="M16 21v-2a5 5 0 0 0-2-4"/>
+        </svg>
+        Agents
+      </button>
       <button class="nav-btn" data-tab="plugins">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <circle cx="12" cy="12" r="3"/><path d="M12 1v6m0 6v6"/><path d="m15.4 17.4 3.2 3.2m-3.2-13.2 3.2-3.2M2.6 10.6 5.8 7.4m13.2 13.2-3.2-3.2M10.6 2.6 7.4 5.8m13.2 13.2-3.2-3.2M2.6 17.4l3.2-3.2"/>
@@ -690,6 +699,109 @@
     </div>
   </section>
 
+  <!-- Agents Tab -->
+  <section id="agents" class="tab">
+    <div class="agents-container">
+      <h2>🧠 Agent Management</h2>
+      <p class="agents-subtitle">Create, monitor, and dispatch tasks to specialized agents.</p>
+
+      <div class="agents-header">
+        <div class="agents-stats">
+          <span id="agentsTotal" class="stat-badge">0 agents</span>
+          <span id="agentsIdle" class="stat-badge active">0 idle</span>
+          <span id="agentsBusy" class="stat-badge warning">0 busy</span>
+          <span id="agentsTasks" class="stat-badge">0 tasks</span>
+        </div>
+        <button id="refreshAgentsBtn" class="toolbar-btn" title="Refresh Agents">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="agents-grid">
+        <div class="agents-panel">
+          <h3>Create Agent</h3>
+          <form id="createAgentForm" class="agents-form">
+            <label for="agentNameInput">Name</label>
+            <input id="agentNameInput" type="text" maxlength="100" required placeholder="e.g. Research Assistant" />
+
+            <label for="agentCapabilitiesInput">Capabilities (comma-separated)</label>
+            <input id="agentCapabilitiesInput" type="text" placeholder="search, summarize, code" />
+
+            <label for="agentAuthTokenInput">Auth Token (optional)</label>
+            <input id="agentAuthTokenInput" type="password" placeholder="Leave blank for default auth flow" />
+
+            <button type="submit" class="btn-primary">Create Agent</button>
+          </form>
+        </div>
+
+        <div class="agents-panel">
+          <h3>Dispatch Task</h3>
+          <form id="createTaskForm" class="agents-form">
+            <label for="taskAgentSelect">Assign To</label>
+            <select id="taskAgentSelect">
+              <option value="">Auto-assign</option>
+            </select>
+
+            <label for="taskDescriptionInput">Task Description</label>
+            <textarea id="taskDescriptionInput" rows="4" required placeholder="Describe the task to execute"></textarea>
+
+            <label for="taskPrioritySelect">Priority</label>
+            <select id="taskPrioritySelect">
+              <option value="normal">Normal</option>
+              <option value="high">High</option>
+              <option value="low">Low</option>
+            </select>
+
+            <button type="submit" class="btn-secondary">Create Task</button>
+          </form>
+        </div>
+      </div>
+
+      <div class="agents-list-panel">
+        <div class="agents-list-header">
+          <h3>Active Agents</h3>
+          <input id="agentSearchInput" type="text" class="plugin-search-input" placeholder="Search agents..." />
+        </div>
+        <div id="agentsList" class="agents-list">
+          <div class="loading-indicator">
+            <svg class="spinner" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+            </svg>
+            <p>Loading agents...</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="agents-list-panel">
+        <div class="agents-list-header">
+          <h3>Task Queue</h3>
+          <div class="plugins-actions">
+            <select id="agentTaskStatusFilter" class="plugin-filter-select">
+              <option value="">All Statuses</option>
+              <option value="pending">Pending</option>
+              <option value="in_progress">In Progress</option>
+              <option value="completed">Completed</option>
+              <option value="failed">Failed</option>
+            </select>
+            <button id="refreshAgentTasksBtn" class="toolbar-btn" title="Refresh Task Queue">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div id="agentTasksList" class="agent-tasks-list">
+          <div class="empty-state">
+            <p>No tasks loaded yet</p>
+            <p class="hint">Create a task to populate the queue.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- Plugins Tab -->
   <section id="plugins" class="tab">
     <div class="plugins-container">
@@ -700,6 +812,7 @@
         <div class="plugins-stats">
           <span id="pluginsCount" class="stat-badge">0 plugins</span>
           <span id="pluginsActive" class="stat-badge active">0 active</span>
+          <span id="pluginsVisible" class="stat-badge">0 shown</span>
           <span id="pluginsUpdates" class="stat-badge warning" style="display:none;">0 updates</span>
         </div>
         <div class="plugins-actions">
@@ -710,6 +823,12 @@
             <option value="tool">Tools</option>
             <option value="integration">Integrations</option>
             <option value="automation">Automation</option>
+          </select>
+          <select id="pluginSortFilter" class="plugin-filter-select" aria-label="Sort plugins">
+            <option value="name_asc">Name (A-Z)</option>
+            <option value="name_desc">Name (Z-A)</option>
+            <option value="enabled_first">Enabled First</option>
+            <option value="newest">Newest Version</option>
           </select>
           <button id="refreshPluginsBtn" class="toolbar-btn" title="Refresh Plugins">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/apps/gui/renderer/renderer.js
+++ b/apps/gui/renderer/renderer.js
@@ -1475,8 +1475,366 @@ document.querySelectorAll('.nav-btn').forEach(btn => {
 // Plugin Marketplace
 // =====================================================================
 
+// =====================================================================
+// Agent Management
+// =====================================================================
+
+let agentRecords = [];
+let agentSearch = '';
+let agentTaskRecords = [];
+let agentTaskStatusFilter = '';
+
+async function fetchAgentStats() {
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/v1/agents/stats`);
+    if (!response.ok) {
+      return;
+    }
+
+    const stats = await response.json();
+    document.getElementById('agentsTotal').textContent = `${stats.total_agents ?? 0} agents`;
+    document.getElementById('agentsIdle').textContent = `${stats.idle_agents ?? 0} idle`;
+    document.getElementById('agentsBusy').textContent = `${stats.busy_agents ?? 0} busy`;
+    document.getElementById('agentsTasks').textContent = `${stats.total_tasks ?? 0} tasks`;
+  } catch (error) {
+    console.error('Failed to fetch agent stats:', error);
+  }
+}
+
+function filterAgents() {
+  if (!agentSearch) {
+    return agentRecords;
+  }
+
+  const query = agentSearch.toLowerCase();
+  return agentRecords.filter((agent) => {
+    const capabilities = (agent.capabilities || []).join(' ');
+    return [agent.name, agent.id, agent.status, capabilities]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+      .includes(query);
+  });
+}
+
+function updateTaskAgentSelect() {
+  const select = document.getElementById('taskAgentSelect');
+  if (!select) return;
+
+  const currentValue = select.value;
+  const options = ['<option value="">Auto-assign</option>'].concat(
+    agentRecords.map((agent) => `<option value="${agent.id}">${agent.name} (${agent.id})</option>`)
+  );
+
+  select.innerHTML = options.join('');
+  if (currentValue && agentRecords.some((a) => a.id === currentValue)) {
+    select.value = currentValue;
+  }
+}
+
+function renderAgents() {
+  const container = document.getElementById('agentsList');
+  if (!container) return;
+
+  const filtered = filterAgents();
+
+  if (filtered.length === 0) {
+    container.innerHTML = `
+      <div class="empty-state">
+        <p>No agents found</p>
+        <p class="hint">Create a new agent or adjust your search query.</p>
+      </div>
+    `;
+    return;
+  }
+
+  container.innerHTML = filtered.map((agent) => {
+    const capabilities = (agent.capabilities || [])
+      .slice(0, 6)
+      .map((cap) => `<span class="agent-chip">${cap}</span>`)
+      .join('');
+
+    return `
+      <div class="agent-card">
+        <h4>${agent.name || agent.id}</h4>
+        <div class="agent-meta">
+          <span>${agent.id}</span>
+          <span class="status-pill ${agent.status === 'busy' ? 'busy' : 'idle'}">${agent.status || 'idle'}</span>
+        </div>
+        <div class="agent-capabilities">${capabilities || '<span class="hint">No capabilities</span>'}</div>
+        <div class="agent-meta">
+          <span>Tasks: ${agent.tasks_completed ?? 0}</span>
+          <span>${agent.created_at ? new Date(agent.created_at).toLocaleString() : 'N/A'}</span>
+        </div>
+        <div class="agent-actions">
+          <button class="btn-secondary" onclick="quickAssignTask('${agent.id}')">Assign Task</button>
+          <button class="btn-danger" onclick="removeAgent('${agent.id}')">Delete</button>
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
+function getTaskBadgeClass(status) {
+  if (status === 'completed') return 'idle';
+  if (status === 'in_progress') return 'busy';
+  if (status === 'failed') return 'busy';
+  return '';
+}
+
+function renderAgentTasks() {
+  const container = document.getElementById('agentTasksList');
+  if (!container) return;
+
+  const filtered = agentTaskStatusFilter
+    ? agentTaskRecords.filter((task) => task.status === agentTaskStatusFilter)
+    : [...agentTaskRecords];
+
+  if (filtered.length === 0) {
+    container.innerHTML = `
+      <div class="empty-state">
+        <p>No tasks found</p>
+        <p class="hint">Try another filter or create a new task.</p>
+      </div>
+    `;
+    return;
+  }
+
+  container.innerHTML = filtered.slice(0, 50).map((task) => `
+    <div class="agent-task-item">
+      <div class="agent-task-main">
+        <h4>${task.description || task.id}</h4>
+        <div class="agent-task-meta">
+          <span>ID: ${task.id}</span>
+          <span>Priority: ${task.priority || 'normal'}</span>
+          <span>Agent: ${task.assigned_agent || 'auto'}</span>
+          <span class="status-pill ${getTaskBadgeClass(task.status)}">${task.status || 'pending'}</span>
+        </div>
+      </div>
+      <div class="agent-task-actions">
+        <button class="btn-secondary" onclick="rerunAgentTask('${task.id}')">Run</button>
+      </div>
+    </div>
+  `).join('');
+}
+
+async function loadAgentTasks() {
+  const container = document.getElementById('agentTasksList');
+  if (container) {
+    container.innerHTML = `
+      <div class="loading-indicator">
+        <svg class="spinner" width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+        </svg>
+        <p>Loading tasks...</p>
+      </div>
+    `;
+  }
+
+  try {
+    const query = agentTaskStatusFilter ? `?status=${encodeURIComponent(agentTaskStatusFilter)}` : '';
+    const response = await fetch(`${BACKEND_URL}/api/v1/agents/tasks${query}`);
+    if (!response.ok) {
+      throw new Error(`Failed to load tasks (${response.status})`);
+    }
+    const data = await response.json();
+    agentTaskRecords = Array.isArray(data) ? data : [];
+    renderAgentTasks();
+  } catch (error) {
+    console.error('Error loading agent tasks:', error);
+    if (container) {
+      container.innerHTML = `
+        <div class="empty-state">
+          <p>Failed to load tasks</p>
+          <p class="hint">Verify backend auth and task routes.</p>
+        </div>
+      `;
+    }
+  }
+}
+
+async function loadAgents() {
+  const container = document.getElementById('agentsList');
+  if (container) {
+    container.innerHTML = `
+      <div class="loading-indicator">
+        <svg class="spinner" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
+        </svg>
+        <p>Loading agents...</p>
+      </div>
+    `;
+  }
+
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/v1/agents/`);
+    if (!response.ok) {
+      throw new Error(`Failed to load agents (${response.status})`);
+    }
+
+    const data = await response.json();
+    agentRecords = Array.isArray(data) ? data : [];
+    updateTaskAgentSelect();
+    renderAgents();
+    fetchAgentStats();
+    loadAgentTasks();
+  } catch (error) {
+    console.error('Error loading agents:', error);
+    if (container) {
+      container.innerHTML = `
+        <div class="empty-state">
+          <p>Failed to load agents</p>
+          <p class="hint">Ensure backend auth and agent routes are available.</p>
+        </div>
+      `;
+    }
+  }
+}
+
+async function createAgent(event) {
+  event.preventDefault();
+  const name = document.getElementById('agentNameInput')?.value.trim();
+  if (!name) return;
+
+  const capabilitiesRaw = document.getElementById('agentCapabilitiesInput')?.value || '';
+  const authToken = document.getElementById('agentAuthTokenInput')?.value.trim();
+  const capabilities = capabilitiesRaw
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const payload = { name, capabilities: capabilities.length > 0 ? capabilities : undefined };
+  if (authToken) {
+    payload.auth_token = authToken;
+  }
+
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/v1/agents/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.detail || `Failed to create agent (${response.status})`);
+    }
+
+    updateStatus('Agent created successfully');
+    document.getElementById('createAgentForm')?.reset();
+    await loadAgents();
+  } catch (error) {
+    console.error('Error creating agent:', error);
+    updateStatus(`Agent creation failed: ${error.message}`);
+  }
+}
+
+async function createAgentTask(event) {
+  event.preventDefault();
+  const description = document.getElementById('taskDescriptionInput')?.value.trim();
+  if (!description) return;
+
+  const agentId = document.getElementById('taskAgentSelect')?.value || undefined;
+  const priority = document.getElementById('taskPrioritySelect')?.value || 'normal';
+
+  const payload = {
+    description,
+    priority
+  };
+
+  if (agentId) {
+    payload.agent_id = agentId;
+  }
+
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/v1/agents/tasks`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.detail || `Failed to create task (${response.status})`);
+    }
+
+    updateStatus('Task created successfully');
+    document.getElementById('createTaskForm')?.reset();
+    await fetchAgentStats();
+    await loadAgentTasks();
+  } catch (error) {
+    console.error('Error creating task:', error);
+    updateStatus(`Task creation failed: ${error.message}`);
+  }
+}
+
+window.quickAssignTask = function quickAssignTask(agentId) {
+  const select = document.getElementById('taskAgentSelect');
+  if (!select) return;
+  select.value = agentId;
+  document.getElementById('taskDescriptionInput')?.focus();
+};
+
+window.removeAgent = async function removeAgent(agentId) {
+  const confirmed = confirm(`Delete agent ${agentId}?`);
+  if (!confirmed) return;
+
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/v1/agents/${agentId}`, {
+      method: 'DELETE'
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.detail || `Failed to delete agent (${response.status})`);
+    }
+    updateStatus(`Deleted agent ${agentId}`);
+    await loadAgents();
+  } catch (error) {
+    console.error('Error deleting agent:', error);
+    updateStatus(`Delete failed: ${error.message}`);
+  }
+};
+
+window.rerunAgentTask = async function rerunAgentTask(taskId) {
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/v1/agents/tasks/${taskId}/execute`, {
+      method: 'POST'
+    });
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.detail || `Failed to execute task (${response.status})`);
+    }
+    updateStatus(`Executed task ${taskId}`);
+    await loadAgentTasks();
+    await fetchAgentStats();
+  } catch (error) {
+    console.error('Error executing task:', error);
+    updateStatus(`Task execution failed: ${error.message}`);
+  }
+};
+
+document.getElementById('refreshAgentsBtn')?.addEventListener('click', loadAgents);
+document.getElementById('createAgentForm')?.addEventListener('submit', createAgent);
+document.getElementById('createTaskForm')?.addEventListener('submit', createAgentTask);
+document.getElementById('agentSearchInput')?.addEventListener('input', (event) => {
+  agentSearch = event.target.value.trim();
+  renderAgents();
+});
+document.getElementById('refreshAgentTasksBtn')?.addEventListener('click', loadAgentTasks);
+document.getElementById('agentTaskStatusFilter')?.addEventListener('change', (event) => {
+  agentTaskStatusFilter = event.target.value;
+  loadAgentTasks();
+});
+
+document.querySelector('[data-tab="agents"]')?.addEventListener('click', () => {
+  loadAgents();
+});
+
 let allPlugins = [];
 let currentPluginFilter = 'all';
+let currentPluginTab = 'all';
+let currentPluginSearch = '';
+let currentPluginSort = 'name_asc';
 
 // Load plugins from backend
 async function loadPlugins() {
@@ -1510,10 +1868,14 @@ async function loadPlugins() {
 function displayPlugins() {
   const pluginsList = document.getElementById('pluginsList');
 
-  // Filter plugins
-  let filtered = allPlugins;
-  if (currentPluginFilter !== 'all') {
-    filtered = allPlugins.filter(p => p.type === currentPluginFilter);
+  let filtered = allPlugins.filter(pluginMatchesTab);
+  filtered = filtered.filter(pluginMatchesTypeFilter);
+  filtered = filtered.filter(pluginMatchesSearchFilter);
+  filtered = sortPlugins(filtered);
+
+  const visibleBadge = document.getElementById('pluginsVisible');
+  if (visibleBadge) {
+    visibleBadge.textContent = `${filtered.length} shown`;
   }
 
   if (filtered.length === 0) {
@@ -1532,10 +1894,10 @@ function displayPlugins() {
   pluginsList.innerHTML = filtered.map(plugin => `
     <div class="plugin-card ${plugin.enabled ? 'enabled' : 'disabled'}">
       <div class="plugin-card-header">
-        <div class="plugin-icon">${getPluginIcon(plugin.type)}</div>
+        <div class="plugin-icon">${getPluginIcon(getPluginType(plugin))}</div>
         <div class="plugin-info">
           <h3 class="plugin-name">${plugin.name || plugin.id}</h3>
-          <span class="plugin-type">${plugin.type}</span>
+          <span class="plugin-type">${getPluginType(plugin)}</span>
         </div>
         <div class="plugin-toggle">
           <label class="toggle-switch">
@@ -1559,6 +1921,63 @@ function displayPlugins() {
       </div>
     </div>
   `).join('');
+}
+
+function getPluginType(plugin) {
+  return plugin.type || plugin.plugin_type || 'unknown';
+}
+
+function pluginMatchesTab(plugin) {
+  if (currentPluginTab === 'installed') {
+    return Boolean(plugin.enabled);
+  }
+  if (currentPluginTab === 'featured') {
+    const tags = plugin.tags || [];
+    return tags.includes('featured') || tags.includes('recommended');
+  }
+  return true;
+}
+
+function pluginMatchesTypeFilter(plugin) {
+  if (currentPluginFilter === 'all') {
+    return true;
+  }
+  return getPluginType(plugin) === currentPluginFilter;
+}
+
+function pluginMatchesSearchFilter(plugin) {
+  if (!currentPluginSearch) {
+    return true;
+  }
+
+  const query = currentPluginSearch.toLowerCase();
+  const searchable = [
+    plugin.name,
+    plugin.id,
+    plugin.description,
+    plugin.author,
+    getPluginType(plugin),
+    ...(plugin.tags || [])
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  return searchable.includes(query);
+}
+
+function sortPlugins(plugins) {
+  const sorted = [...plugins];
+  if (currentPluginSort === 'name_desc') {
+    sorted.sort((a, b) => (b.name || b.id || '').localeCompare(a.name || a.id || ''));
+  } else if (currentPluginSort === 'enabled_first') {
+    sorted.sort((a, b) => Number(Boolean(b.enabled)) - Number(Boolean(a.enabled)));
+  } else if (currentPluginSort === 'newest') {
+    sorted.sort((a, b) => (b.version || '0').localeCompare(a.version || '0', undefined, { numeric: true }));
+  } else {
+    sorted.sort((a, b) => (a.name || a.id || '').localeCompare(b.name || b.id || ''));
+  }
+  return sorted;
 }
 
 // Get icon for plugin type
@@ -1676,6 +2095,29 @@ window.executePlugin = async function(pluginId) {
 document.getElementById('pluginTypeFilter')?.addEventListener('change', (e) => {
   currentPluginFilter = e.target.value;
   displayPlugins();
+});
+
+document.getElementById('pluginSortFilter')?.addEventListener('change', (e) => {
+  currentPluginSort = e.target.value;
+  displayPlugins();
+});
+
+document.getElementById('pluginSearchInput')?.addEventListener('input', (e) => {
+  currentPluginSearch = e.target.value.trim();
+  displayPlugins();
+});
+
+document.getElementById('refreshPluginsBtn')?.addEventListener('click', () => {
+  loadPlugins();
+});
+
+document.querySelectorAll('.plugin-tab-btn').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.plugin-tab-btn').forEach((tabBtn) => tabBtn.classList.remove('active'));
+    btn.classList.add('active');
+    currentPluginTab = btn.dataset.pluginTab || 'all';
+    displayPlugins();
+  });
 });
 
 // Load plugins when tab is opened
@@ -2499,8 +2941,8 @@ document.getElementById('exportBtn')?.addEventListener('click', () => {
 // Model Management
 // =====================================================================
 
-let allModels = [];
-let installedModels = [];
+let catalogModels = [];
+let localInstalledModels = [];
 let downloadSocket = null;
 let currentFilter = 'all';
 
@@ -2511,14 +2953,14 @@ async function loadModels() {
     const availableResponse = await fetch(`${BACKEND_URL}/models/available`);
     if (availableResponse.ok) {
       const data = await availableResponse.json();
-      allModels = data.models || [];
+      catalogModels = data.models || [];
     }
 
     // Load installed models
     const installedResponse = await fetch(`${BACKEND_URL}/models/installed`);
     if (installedResponse.ok) {
       const data = await installedResponse.json();
-      installedModels = data.models || [];
+      localInstalledModels = data.models || [];
     }
 
     // Load system specs and recommendations
@@ -2553,11 +2995,11 @@ function updateModelStats() {
   const installedCount = document.getElementById('modelsInstalled');
 
   if (availableCount) {
-    availableCount.textContent = `${allModels.length} available`;
+    availableCount.textContent = `${catalogModels.length} available`;
   }
 
   if (installedCount) {
-    const installed = allModels.filter(m => m.installed).length;
+    const installed = catalogModels.filter(m => m.installed).length;
     installedCount.textContent = `${installed} installed`;
   }
 }
@@ -2588,12 +3030,12 @@ function renderModels() {
   const selectedCategory = categoryFilter ? categoryFilter.value : 'all';
 
   // Filter models
-  let filteredModels = allModels;
+  let filteredModels = catalogModels;
   if (selectedCategory !== 'all') {
     if (selectedCategory === 'recommended') {
-      filteredModels = allModels.filter(m => m.recommended);
+      filteredModels = catalogModels.filter(m => m.recommended);
     } else {
-      filteredModels = allModels.filter(m => m.category === selectedCategory);
+      filteredModels = catalogModels.filter(m => m.category === selectedCategory);
     }
   }
 
@@ -2742,7 +3184,7 @@ async function downloadModel(modelId) {
   if (!downloadModal) return;
 
   // Find model info
-  const model = allModels.find(m => m.id === modelId);
+  const model = catalogModels.find(m => m.id === modelId);
   if (model) {
     downloadModelName.textContent = model.name;
   }
@@ -2878,7 +3320,7 @@ if (modelsTab) {
   modelsTab.addEventListener('click', () => {
     // Delay loading to ensure tab is visible
     setTimeout(() => {
-      if (!allModels.length) {
+      if (!catalogModels.length) {
         loadModels();
       }
     }, 100);

--- a/apps/gui/renderer/styles.css
+++ b/apps/gui/renderer/styles.css
@@ -1043,6 +1043,190 @@ footer {
 }
 
 /* ==========================================
+   Agents Tab
+   ========================================== */
+
+.agents-container {
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.agents-subtitle {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.agents-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.agents-stats {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.agents-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.agents-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.agents-panel h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.agents-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.agents-form input,
+.agents-form textarea,
+.agents-form select {
+  width: 100%;
+  background: var(--background);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.agents-list-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+.agents-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.8rem;
+}
+
+.agents-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(290px, 1fr));
+  gap: 0.75rem;
+}
+
+.agent-card {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.9rem;
+}
+
+.agent-card h4 {
+  margin: 0;
+}
+
+.agent-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  margin: 0.5rem 0;
+}
+
+.agent-capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0.5rem 0;
+}
+
+.agent-chip {
+  background: var(--surface-hover);
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.agent-actions {
+  display: flex;
+  gap: 0.45rem;
+  margin-top: 0.65rem;
+}
+
+.agent-actions button {
+  flex: 1;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: var(--surface-hover);
+}
+
+.status-pill.idle {
+  color: var(--success);
+}
+
+.status-pill.busy {
+  color: #f59e0b;
+}
+
+.agent-tasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.agent-task-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.7rem;
+  align-items: center;
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem 0.9rem;
+}
+
+.agent-task-main h4 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.agent-task-meta {
+  margin-top: 0.3rem;
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+}
+
+.agent-task-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+/* ==========================================
    Plugins Tab
    ========================================== */
 
@@ -1080,6 +1264,11 @@ footer {
 .stat-badge.active {
   background: rgba(16, 185, 129, 0.1);
   color: var(--success);
+}
+
+.stat-badge.warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
 }
 
 .plugins-filter select {

--- a/docs/status/DEVELOPMENT_REMAINING.md
+++ b/docs/status/DEVELOPMENT_REMAINING.md
@@ -1,0 +1,43 @@
+# Windows AI — Development Remaining (Snapshot)
+
+**Date:** 2026-04-13 (updated)
+**Source of truth:** `ROADMAP.md` (last updated 2026-03-10)
+
+This checklist captures all roadmap items still marked incomplete (`[ ]`) in the current master roadmap.
+
+## Phase 1 — Stability & Completeness
+- Wire up remaining XR features when OpenXR hardware is available.
+- Reach 60%+ overall test coverage (roadmap notes current ~40%).
+
+## Phase 2 — Feature Completion
+### GUI
+- Plugin marketplace browser in GUI.
+- Multi-agent task flow visualization (graph/timeline).
+- Accessibility improvements (screen reader support, keyboard navigation).
+- Windows Hello biometric login integration.
+
+### Mobile Companion
+- Complete `mobile/` TypeScript companion app integration.
+- QR pairing flow between desktop and mobile.
+- Remote monitoring of desktop AI agent.
+- Voice commands via mobile.
+
+## Phase 3 — Production Hardening
+### Build & Distribution
+- Verify/test PyInstaller build on Windows 10/11.
+- Validate Electron NSIS installer + auto-update.
+- Produce portable ZIP distribution.
+- Create Windows Store MSIX package.
+- Add CI/CD automated release pipeline on tag push.
+
+## Phase 4 — Ecosystem & Community
+### Community
+- Plugin marketplace website.
+- Community Discord / GitHub Discussions.
+- Plugin of the week / featured plugins.
+
+### XR/AR/VR Expansion
+- Full spatial UI framework completion.
+- HoloLens/Quest integration testing.
+- AR overlay for Windows desktop.
+- Voice + gesture AI interaction in XR spaces.


### PR DESCRIPTION
### Motivation
- Add a first-class Agents management experience to the Electron renderer to create/monitor/dispatch tasks to agents and surface live stats. 
- Improve the Plugin Marketplace UX with filtering, search, sorting and tabbed views to make plugin discovery easier. 
- Clean up model list variable names for clarity and add styling for the new UI components. 
- Document remaining development work in a new snapshot file for visibility.

### Description
- Added an "Agents" nav button and a complete Agents tab to `apps/gui/renderer/index.html` including create agent form, task dispatch form, stats, agent list, and task queue panels. 
- Implemented agent management frontend logic in `apps/gui/renderer/renderer.js` including fetch/load/create/delete agents, fetch/load/create/execute tasks, agent stats polling, search/filtering, and convenient UI actions (`quickAssignTask`, `removeAgent`, `rerunAgentTask`). 
- Enhanced the Plugin Marketplace in `renderer.js` with tab filtering (`all`/`installed`/`featured`), type-safe plugin type detection (`getPluginType`), search filtering, sorting (`name_asc`, `name_desc`, `enabled_first`, `newest`) and a visible-count badge, plus minor icon/type display fixes. 
- Renamed model-related variables for clarity (`allModels` -> `catalogModels`, `installedModels` -> `localInstalledModels`) and updated model load/render flows to use the new names. 
- Added styles for the Agents UI and some plugin badges in `apps/gui/renderer/styles.css`. 
- Updated `ROADMAP.md` with the Agents wizard as done and added a new `docs/status/DEVELOPMENT_REMAINING.md` snapshot file listing remaining roadmap items.

### Testing
- No new automated unit tests were added for the UI changes in this PR. 
- Existing frontend build and lint steps were exercised locally via `npm run build` and `npm run lint`, and completed without errors. 
- Project backend unit tests were executed with `pytest` against the current codebase and completed successfully under the local CI configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4233d4b88326b10899652e4905de)